### PR TITLE
Update keybidings using vs-code-default-keybindings

### DIFF
--- a/.github/workflows/update-keybindings.yml
+++ b/.github/workflows/update-keybindings.yml
@@ -1,0 +1,38 @@
+name: Update keybindings in new PR
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+
+jobs:
+   update_packages:
+    name: Update keybindings
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update keybindings in package.json
+        run: |
+          python3 scripts/update_keybindings.py
+
+      - name: Diff
+        id: diff
+        run: |
+          if $(git diff --exit-code); then
+            echo "has-diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR
+        if: steps.diff.outputs.has-diff == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update keybindings"
+          title: "chore: update keybindings"
+          body: This PR updates the keybindings in all extensions
+          branch: master
+          base: update-using-vs-code-default-keybindings

--- a/linuxkeybindings/README.md
+++ b/linuxkeybindings/README.md
@@ -21,6 +21,8 @@
 
 Use Linux Keybindings on any OS
 
+Keybindings provided by https://github.com/codebling/vs-code-default-keybindings - Thank you!
+
 This extension does not remove any existing bindings. On the same os as that of
 the keybindings that means everything will be bound twice. On other OS' that
 means that the keybindings will be in addition to the default (note that they

--- a/linuxkeybindings/package.json
+++ b/linuxkeybindings/package.json
@@ -9,9 +9,9 @@
 	"icon": "Linux.png",
 	"license": "BSD-2-Clause-Patent",
 	"publisher": "fredhappyface",
-	"version": "1.87.2",
+	"version": "1.91.1",
 	"engines": {
-		"vscode": "^1.87.2"
+		"vscode": "^1.91.1"
 	},
 	"categories": [
 		"Keymaps"
@@ -276,24 +276,14 @@
 				"when": "editorHasMultipleSelections && textInputFocus"
 			},
 			{
-				"key": "enter",
-				"command": "inlineChat.accept",
-				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatVisible && !inlineChatEmpty"
-			},
-			{
-				"key": "enter",
-				"command": "notebook.cell.chat.accept",
-				"when": "inlineChatFocused && notebookCellChatFocused"
-			},
-			{
 				"key": "ctrl+down",
 				"command": "notebook.cell.chat.arrowOutDown",
-				"when": "inlineChatFocused && inlineChatInnerCursorLast && notebookCellChatFocused && !accessibilityModeEnabled"
+				"when": "inlineChatFocused && inlineChatInnerCursorLast && notebookCellChatFocused && !accessibilityModeEnabled && !notebookCellEditorFocused"
 			},
 			{
 				"key": "ctrl+up",
 				"command": "notebook.cell.chat.arrowOutUp",
-				"when": "inlineChatFocused && inlineChatInnerCursorFirst && notebookCellChatFocused && !accessibilityModeEnabled"
+				"when": "inlineChatFocused && inlineChatInnerCursorFirst && notebookCellChatFocused && !accessibilityModeEnabled && !notebookCellEditorFocused"
 			},
 			{
 				"key": "ctrl+up",
@@ -316,19 +306,19 @@
 				"when": "editorTextFocus && inlineChatVisible && !accessibilityModeEnabled && !inlineChatFocused && !isEmbeddedDiffEditor && inlineChatOuterCursorPosition == 'below'"
 			},
 			{
+				"key": "escape",
+				"command": "notebook.cell.chat.acceptChanges",
+				"when": "inlineChatFocused && notebookCellChatFocused && notebookChatUserDidEdit && !notebookCellEditorFocused"
+			},
+			{
 				"key": "down",
-				"command": "inlineChat.nextFromHistory",
-				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatInnerCursorEnd"
+				"command": "notebook.cell.chat.nextFromHistory",
+				"when": "inlineChatFocused && notebookCellChatFocused"
 			},
 			{
 				"key": "up",
-				"command": "inlineChat.previousFromHistory",
-				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatInnerCursorStart"
-			},
-			{
-				"key": "escape",
-				"command": "notebook.cell.chat.acceptChanges",
-				"when": "inlineChatFocused && notebookCellChatFocused && notebookChatUserDidEdit"
+				"command": "notebook.cell.chat.previousFromHistory",
+				"when": "inlineChatFocused && notebookCellChatFocused"
 			},
 			{
 				"key": "f12",
@@ -351,7 +341,7 @@
 				"when": "inReferenceSearchEditor || referenceSearchVisible"
 			},
 			{
-				"key": "shift+enter",
+				"key": "ctrl+enter",
 				"command": "refactorPreview.apply",
 				"when": "refactorPreview.enabled && refactorPreview.hasCheckedChanges && focusedView == 'refactorPreview'"
 			},
@@ -372,13 +362,8 @@
 			},
 			{
 				"key": "escape",
-				"command": "inlineChat.cancel",
-				"when": "inlineChatHasProvider && inlineChatVisible"
-			},
-			{
-				"key": "escape",
-				"command": "inlineChat.close",
-				"when": "inlineChatHasProvider && inlineChatVisible"
+				"command": "inlineChat.discard",
+				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatUserDidEdit"
 			},
 			{
 				"key": "ctrl+f",
@@ -393,12 +378,12 @@
 			{
 				"key": "ctrl+up",
 				"command": "chat.action.focus",
-				"when": "chatCursorAtTop && inChatInput"
+				"when": "chatCursorAtTop && inChatInput && chatLocation == 'panel'"
 			},
 			{
 				"key": "ctrl+up",
 				"command": "chat.action.focus",
-				"when": "inChatInput && isLinux || inChatInput && isWindows"
+				"when": "inChatInput && isLinux && chatLocation == 'panel' || inChatInput && isWindows && chatLocation == 'panel'"
 			},
 			{
 				"key": "shift+escape",
@@ -635,6 +620,21 @@
 				"key": "escape",
 				"command": "editor.action.inlineEdit.reject",
 				"when": "inlineEditVisible && !editorReadonly"
+			},
+			{
+				"key": "escape",
+				"command": "editor.action.inlineEdits.hide",
+				"when": "inlineEditsVisible"
+			},
+			{
+				"key": "alt+]",
+				"command": "editor.action.inlineEdits.showNext",
+				"when": "inlineEditsVisible && !editorReadonly"
+			},
+			{
+				"key": "alt+[",
+				"command": "editor.action.inlineEdits.showPrevious",
+				"when": "inlineEditsVisible && !editorReadonly"
 			},
 			{
 				"key": "escape",
@@ -1123,6 +1123,16 @@
 				"when": "hasSymbols"
 			},
 			{
+				"key": "escape",
+				"command": "editor.hideDropWidget",
+				"when": "dropWidgetVisible"
+			},
+			{
+				"key": "escape",
+				"command": "editor.hidePasteWidget",
+				"when": "pasteWidgetVisible"
+			},
+			{
 				"key": "ctrl+k ctrl+.",
 				"command": "editor.removeManualFoldingRanges",
 				"when": "editorTextFocus && foldingEnabled"
@@ -1130,6 +1140,11 @@
 			{
 				"key": "ctrl+k ctrl+l",
 				"command": "editor.toggleFold",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
+				"key": "ctrl+k ctrl+shift+l",
+				"command": "editor.toggleFoldRecursively",
 				"when": "editorTextFocus && foldingEnabled"
 			},
 			{
@@ -1163,34 +1178,29 @@
 				"when": "isReadingLineWithInlayHints"
 			},
 			{
-				"key": "escape",
-				"command": "inlineChat.acceptChanges",
-				"when": "inlineChatHasProvider && inlineChatUserDidEdit && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatUserDidEdit && inlineChatVisible && config.inlineChat.mode != 'preview'"
-			},
-			{
-				"key": "escape",
-				"command": "inlineChat.discard",
-				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatUserDidEdit"
-			},
-			{
-				"key": "escape",
-				"command": "inlineChat.stop",
-				"when": "inlineChatHasActiveRequest && inlineChatHasProvider && inlineChatVisible && !inlineChatEmpty"
-			},
-			{
 				"key": "tab",
 				"command": "insertSnippet",
 				"when": "editorTextFocus && hasSnippetCompletions && !editorTabMovesFocus && !inSnippetMode"
 			},
 			{
-				"key": "meta+enter",
+				"key": "ctrl+enter",
 				"command": "interactive.execute",
 				"when": "activeEditor == 'workbench.editor.interactive'"
 			},
 			{
+				"key": "shift+enter",
+				"command": "interactive.execute",
+				"when": "config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "enter",
+				"command": "interactive.execute",
+				"when": "!config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+			},
+			{
 				"key": "escape",
 				"command": "notebook.cell.chat.discard",
-				"when": "inlineChatFocused && notebookCellChatFocused && !notebookChatUserDidEdit"
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused && !notebookChatUserDidEdit"
 			},
 			{
 				"key": "pagedown",
@@ -1200,7 +1210,7 @@
 			{
 				"key": "shift+pagedown",
 				"command": "notebook.cell.cursorPageDownSelect",
-				"when": "editorTextFocus && inputFocus && notebookEditorFocused"
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused"
 			},
 			{
 				"key": "pageup",
@@ -1210,12 +1220,12 @@
 			{
 				"key": "shift+pageup",
 				"command": "notebook.cell.cursorPageUpSelect",
-				"when": "editorTextFocus && inputFocus && notebookEditorFocused"
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused"
 			},
 			{
 				"key": "meta+enter",
 				"command": "notebook.cell.execute",
-				"when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+				"when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || !notebookCellExecuting && notebookCellType == 'code' && notebookCellListFocused || inlineChatFocused && notebookCellChatFocused && notebookKernelCount > 0 || !notebookCellExecuting && notebookCellType == 'code' && notebookCellListFocused || inlineChatFocused && notebookCellChatFocused && notebookKernelSourceCount > 0 || inlineChatFocused && notebookCellChatFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code'"
 			},
 			{
 				"key": "alt+enter",
@@ -1312,19 +1322,24 @@
 				"command": "workbench.action.addComment"
 			},
 			{
-				"key": "enter",
-				"command": "workbench.action.chat.acceptInput",
-				"when": "inChatInput && textInputFocus"
+				"key": "ctrl+/",
+				"command": "workbench.action.chat.attachContext",
+				"when": "inChatInput"
 			},
 			{
 				"key": "ctrl+alt+enter",
 				"command": "workbench.action.chat.runInTerminal",
-				"when": "hasChatProvider && inChat"
+				"when": "accessibleViewInCodeBlock && chatIsEnabled || chatIsEnabled && inChat"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.chat.submit",
+				"when": "chatInputHasText && inChatInput && !chatSessionRequestInProgress"
 			},
 			{
 				"key": "ctrl+enter",
 				"command": "workbench.action.chat.submitSecondaryAgent",
-				"when": "inChatInput && textInputFocus"
+				"when": "chatInputHasText && inChatInput && !chatInputHasAgent && !chatSessionRequestInProgress"
 			},
 			{
 				"key": "alt+f5",
@@ -1438,23 +1453,18 @@
 			},
 			{
 				"key": "ctrl+enter",
-				"command": "inlineChat.acceptChanges",
-				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.mode != 'preview'"
-			},
-			{
-				"key": "ctrl+enter",
 				"command": "notebook.cell.chat.acceptChanges",
-				"when": "inlineChatFocused && notebookCellChatFocused"
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused"
 			},
 			{
 				"key": "tab",
 				"command": "jumpToNextSnippetPlaceholder",
-				"when": "editorTextFocus && hasNextTabstop && inSnippetMode"
+				"when": "hasNextTabstop && inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "shift+tab",
 				"command": "jumpToPrevSnippetPlaceholder",
-				"when": "editorTextFocus && hasPrevTabstop && inSnippetMode"
+				"when": "hasPrevTabstop && inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "escape",
@@ -1464,12 +1474,12 @@
 			{
 				"key": "shift+escape",
 				"command": "leaveSnippet",
-				"when": "editorTextFocus && inSnippetMode"
+				"when": "inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "escape",
 				"command": "leaveSnippet",
-				"when": "editorTextFocus && inSnippetMode"
+				"when": "inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "shift+escape",
@@ -1642,7 +1652,7 @@
 				"when": "editorFocus && renameInputVisible && !isComposing"
 			},
 			{
-				"key": "shift+enter",
+				"key": "ctrl+enter",
 				"command": "acceptRenameInputWithPreview",
 				"when": "config.editor.rename.enablePreview && editorFocus && renameInputVisible && !isComposing"
 			},
@@ -1672,29 +1682,9 @@
 				"when": "renameInputVisible"
 			},
 			{
-				"key": "tab",
-				"command": "focusNextRenameSuggestion",
-				"when": "renameInputVisible"
-			},
-			{
 				"key": "up",
 				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputVisible && !renameInputFocused"
-			},
-			{
-				"key": "alt",
-				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputFocused && renameInputVisible"
-			},
-			{
-				"key": "alt",
-				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputFocused && renameInputVisible"
-			},
-			{
-				"key": "shift+tab",
-				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputVisible && !renameInputFocused"
+				"when": "renameInputVisible"
 			},
 			{
 				"key": "ctrl+shift+l",
@@ -1857,6 +1847,16 @@
 				"when": "!accessibilityHelpIsShown"
 			},
 			{
+				"key": "alt+k",
+				"command": "editor.action.accessibilityHelpConfigureKeybindings",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
+				"key": "alt+h",
+				"command": "editor.action.accessibilityHelpOpenHelpLink",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
 				"key": "alt+f2",
 				"command": "editor.action.accessibleView"
 			},
@@ -1880,14 +1880,24 @@
 				"when": "accessibleViewIsShown && accessibleViewSupportsNavigation"
 			},
 			{
+				"key": "ctrl+alt+pagedown",
+				"command": "editor.action.accessibleViewNextCodeBlock",
+				"when": "accessibleViewContainsCodeBlocks && accessibleViewCurrentProviderId == 'panelChat'"
+			},
+			{
 				"key": "alt+[",
 				"command": "editor.action.accessibleViewPrevious",
 				"when": "accessibleViewIsShown && accessibleViewSupportsNavigation"
 			},
 			{
+				"key": "ctrl+alt+pageup",
+				"command": "editor.action.accessibleViewPreviousCodeBlock",
+				"when": "accessibleViewContainsCodeBlocks && accessibleViewCurrentProviderId == 'panelChat'"
+			},
+			{
 				"key": "ctrl+k ctrl+k",
 				"command": "editor.action.defineKeybinding",
-				"when": "resource == 'vscode-userdata:/home/vboxuser/.config/VSCodium/User/keybindings.json'"
+				"when": "resource == 'vscode-userdata:/home/runner/work/vs-code-default-keybindings/vs-code-default-keybindings/scripts/get_default_keybindings/empty2/User/keybindings.json'"
 			},
 			{
 				"key": "tab",
@@ -2000,6 +2010,16 @@
 				"when": "inSearchEditor"
 			},
 			{
+				"key": "escape",
+				"command": "inlineChat.close",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "escape",
+				"command": "inlineChat.discardHunkChange",
+				"when": "inlineChatHasProvider && inlineChatVisible && inlineChatResponseType == 'messagesAndEdits'"
+			},
+			{
 				"key": "ctrl+i",
 				"command": "inlineChat.holdForSpeech",
 				"when": "hasSpeechProvider && inlineChatHasProvider && inlineChatVisible && textInputFocus"
@@ -2015,9 +2035,9 @@
 				"when": "inlineChatHasProvider && inlineChatVisible"
 			},
 			{
-				"key": "escape",
-				"command": "inlineChat.quickVoice.Cancel",
-				"when": "hasSpeechProvider && inlineChat.quickChatInProgress"
+				"key": "ctrl+r",
+				"command": "inlineChat.regenerate",
+				"when": "inlineChatHasProvider && inlineChatVisible"
 			},
 			{
 				"key": "ctrl+k i",
@@ -2035,14 +2055,29 @@
 				"when": "inlineChatHasStashedSession && !editorReadonly"
 			},
 			{
+				"key": "ctrl+down",
+				"command": "inlineChat.viewInChat",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
 				"key": "down",
 				"command": "interactive.history.next",
 				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.interactive' && interactiveInputCursorAtBoundary != 'none' && interactiveInputCursorAtBoundary != 'top'"
 			},
 			{
+				"key": "down",
+				"command": "interactive.history.next",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.repl' && interactiveInputCursorAtBoundary != 'none' && interactiveInputCursorAtBoundary != 'top'"
+			},
+			{
 				"key": "up",
 				"command": "interactive.history.previous",
 				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.interactive' && interactiveInputCursorAtBoundary != 'bottom' && interactiveInputCursorAtBoundary != 'none'"
+			},
+			{
+				"key": "up",
+				"command": "interactive.history.previous",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.repl' && interactiveInputCursorAtBoundary != 'bottom' && interactiveInputCursorAtBoundary != 'none'"
 			},
 			{
 				"key": "ctrl+end",
@@ -2155,7 +2190,7 @@
 				"when": "listFocus && listSupportsFind"
 			},
 			{
-				"key": "ctrl+f",
+				"key": "ctrl+alt+f",
 				"command": "list.find",
 				"when": "listFocus && listSupportsFind"
 			},
@@ -2230,6 +2265,11 @@
 				"when": "listFocus && listSupportsMultiselect && !inputFocus && !treestickyScrollFocused"
 			},
 			{
+				"key": "ctrl+k ctrl+i",
+				"command": "list.showHover",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
 				"key": "space",
 				"command": "list.toggleExpand",
 				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
@@ -2250,9 +2290,14 @@
 				"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused && activeEditor == 'workbench.editor.notebook' && notebookCellType == 'code'"
 			},
 			{
+				"key": "enter",
+				"command": "notebook.cell.chat.accept",
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused"
+			},
+			{
 				"key": "ctrl+enter",
 				"command": "notebook.cell.chat.acceptChanges",
-				"when": "notebookEditorFocused && !inputFocus && notebookChatOuterFocusPosition == 'below'"
+				"when": "notebookEditorFocused && !inputFocus && !notebookCellEditorFocused && notebookChatOuterFocusPosition == 'below'"
 			},
 			{
 				"key": "ctrl+down",
@@ -2273,6 +2318,16 @@
 				"key": "ctrl+up",
 				"command": "notebook.cell.chat.focusPreviousCell",
 				"when": "inlineChatFocused && notebookCellChatFocused"
+			},
+			{
+				"key": "ctrl+k i",
+				"command": "notebook.cell.chat.start",
+				"when": "config.notebook.experimental.cellChat && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus || config.notebook.experimental.generate && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "notebook.cell.chat.start",
+				"when": "config.notebook.experimental.cellChat && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus || config.notebook.experimental.generate && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus"
 			},
 			{
 				"key": "alt+delete",
@@ -2302,7 +2357,7 @@
 			{
 				"key": "delete",
 				"command": "notebook.cell.delete",
-				"when": "notebookEditorFocused && !inputFocus"
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputInputFocused"
 			},
 			{
 				"key": "shift+alt+d",
@@ -2312,7 +2367,7 @@
 			{
 				"key": "enter",
 				"command": "notebook.cell.edit",
-				"when": "notebookCellListFocused && notebookEditable && !editorHoverFocused && !inputFocus"
+				"when": "notebookCellListFocused && notebookEditable && !editorHoverFocused && !inputFocus && !notebookOutputInputFocused"
 			},
 			{
 				"key": "ctrl+k ctrl+c",
@@ -2365,6 +2420,11 @@
 				"when": "notebookEditorFocused && !inputFocus"
 			},
 			{
+				"key": "ctrl+.",
+				"command": "notebook.cell.openFailureActions",
+				"when": "notebookCellFocused && notebookCellHasErrorDiagnostics && !notebookCellEditorFocused"
+			},
+			{
 				"key": "ctrl+k ctrl+shift+\\",
 				"command": "notebook.cell.split",
 				"when": "editorTextFocus && notebookCellEditable && notebookEditable && notebookEditorFocused"
@@ -2410,19 +2470,9 @@
 				"when": "notebookEditorFocused && notebookOutputFocused"
 			},
 			{
-				"key": "ctrl+alt+pagedown",
-				"command": "notebook.focusNextEditor",
-				"when": "notebookEditorFocused"
-			},
-			{
 				"key": "up",
 				"command": "notebook.focusPreviousEditor",
 				"when": "config.notebook.navigation.allowNavigateToSurroundingCells && notebookCursorNavigationMode && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && !notebookCellMarkdownEditMode && notebookCellType == 'markup'"
-			},
-			{
-				"key": "ctrl+alt+pageup",
-				"command": "notebook.focusPreviousEditor",
-				"when": "notebookEditorFocused"
 			},
 			{
 				"key": "ctrl+home",
@@ -2559,6 +2609,106 @@
 				"when": "problemFocus"
 			},
 			{
+				"key": "ctrl+alt+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+down",
+				"command": "quickInput.next",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "down",
+				"command": "quickInput.next",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+down",
+				"command": "quickInput.nextSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+down",
+				"command": "quickInput.nextSeparatorWithQuickAccessFallback",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+up",
+				"command": "quickInput.previous",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "up",
+				"command": "quickInput.previous",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+up",
+				"command": "quickInput.previousSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+up",
+				"command": "quickInput.previousSeparatorWithQuickAccessFallback",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
 				"key": "space",
 				"command": "refactorPreview.toggleCheckedState",
 				"when": "listFocus && refactorPreview.enabled && !inputFocus && !treestickyScrollFocused"
@@ -2577,6 +2727,11 @@
 				"key": "ctrl+enter",
 				"command": "scm.acceptInput",
 				"when": "scmRepository"
+			},
+			{
+				"key": "escape",
+				"command": "scm.clearInput",
+				"when": "scmRepository && !suggestWidgetVisible"
 			},
 			{
 				"key": "alt+down",
@@ -2810,8 +2965,7 @@
 			},
 			{
 				"key": "ctrl+; ctrl+shift+i",
-				"command": "testing.toggleInlineCoverage",
-				"when": "testing.isTestCoverageOpen"
+				"command": "testing.toggleInlineCoverage"
 			},
 			{
 				"key": "ctrl+; ctrl+i",
@@ -2877,6 +3031,10 @@
 				"when": "inputFocus && navigableContainerFocused || navigableContainerFocused && treestickyScrollFocused || navigableContainerFocused && !listFocus || navigableContainerFocused && listScrollAtBoundary == 'both' || navigableContainerFocused && listScrollAtBoundary == 'top'"
 			},
 			{
+				"key": "ctrl+escape",
+				"command": "workbench.action.chat.cancel"
+			},
+			{
 				"key": "ctrl+down",
 				"command": "workbench.action.chat.focusInput",
 				"when": "inChat && !inChatInput"
@@ -2884,42 +3042,36 @@
 			{
 				"key": "ctrl+i",
 				"command": "workbench.action.chat.holdToVoiceChatInChatView",
-				"when": "hasChatProvider && hasSpeechProvider && !editorFocus && !inChatInput && !inlineChatFocused"
-			},
-			{
-				"key": "ctrl+enter",
-				"command": "workbench.action.chat.insertCodeBlock",
-				"when": "hasChatProvider && inChat && !inChatInput"
+				"when": "chatIsEnabled && hasSpeechProvider && !chatSessionRequestInProgress && !editorFocus && !inChatInput && !inlineChatFocused && !notebookEditorFocused"
 			},
 			{
 				"key": "ctrl+l",
 				"command": "workbench.action.chat.newChat",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+alt+pagedown",
 				"command": "workbench.action.chat.nextCodeBlock",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+f9",
 				"command": "workbench.action.chat.nextFileTree",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+alt+i",
-				"command": "workbench.action.chat.open",
-				"when": "hasChatProvider"
+				"command": "workbench.action.chat.open"
 			},
 			{
 				"key": "ctrl+alt+pageup",
 				"command": "workbench.action.chat.previousCodeBlock",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+shift+f9",
 				"command": "workbench.action.chat.previousFileTree",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "delete",
@@ -2927,14 +3079,19 @@
 				"when": "inChat && !inChatInput"
 			},
 			{
+				"key": "ctrl+shift+enter",
+				"command": "workbench.action.chat.sendToNewChat",
+				"when": "chatInputHasText && inChatInput && !chatSessionRequestInProgress"
+			},
+			{
 				"key": "ctrl+i",
 				"command": "workbench.action.chat.startVoiceChat",
-				"when": "hasChatProvider && hasSpeechProvider && inChatInput && !chatSessionRequestInProgress && !editorFocus && !inlineChatHasActiveRequest && !inlineVoiceChatInProgress && !quickVoiceChatInProgress && !voiceChatGettingReady && !voiceChatInEditorInProgress && !voiceChatInViewInProgress || hasChatProvider && hasSpeechProvider && inlineChatFocused && !chatSessionRequestInProgress && !editorFocus && !inlineChatHasActiveRequest && !inlineVoiceChatInProgress && !quickVoiceChatInProgress && !voiceChatGettingReady && !voiceChatInEditorInProgress && !voiceChatInViewInProgress"
+				"when": "chatIsEnabled && hasSpeechProvider && inChatInput && !chatSessionRequestInProgress && !editorFocus && !notebookEditorFocused && !scopedVoiceChatGettingReady && !speechToTextInProgress && !terminalChatActiveRequest || chatIsEnabled && hasSpeechProvider && inlineChatFocused && !chatSessionRequestInProgress && !editorFocus && !notebookEditorFocused && !scopedVoiceChatGettingReady && !speechToTextInProgress && !terminalChatActiveRequest"
 			},
 			{
 				"key": "ctrl+i",
 				"command": "workbench.action.chat.stopListeningAndSubmit",
-				"when": "hasChatProvider && hasSpeechProvider && inChatInput && voiceChatInProgress || hasChatProvider && hasSpeechProvider && inlineChatFocused && voiceChatInProgress"
+				"when": "inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'view' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'view'"
 			},
 			{
 				"key": "ctrl+w",
@@ -3052,7 +3209,7 @@
 			{
 				"key": "ctrl+alt+v",
 				"command": "workbench.action.editorDictation.start",
-				"when": "hasSpeechProvider && !editorDictation.inProgress && !editorReadonly"
+				"when": "hasSpeechProvider && !editorReadonly && !speechToTextInProgress"
 			},
 			{
 				"key": "ctrl+k p",
@@ -3380,7 +3537,7 @@
 			{
 				"key": "ctrl+shift+alt+i",
 				"command": "workbench.action.quickchat.toggle",
-				"when": "hasChatProvider"
+				"when": "chatIsEnabled"
 			},
 			{
 				"key": "ctrl+q",
@@ -3424,11 +3581,6 @@
 				"command": "workbench.action.showCommands"
 			},
 			{
-				"key": "ctrl+k ctrl+i",
-				"command": "workbench.action.showTreeHover",
-				"when": "customTreeView && listFocus && !inputFocus && !treestickyScrollFocused"
-			},
-			{
 				"key": "ctrl+\\",
 				"command": "workbench.action.splitEditor"
 			},
@@ -3461,6 +3613,76 @@
 				"key": "ctrl+shift+b",
 				"command": "workbench.action.tasks.build",
 				"when": "taskCommandsRegistered"
+			},
+			{
+				"key": "shift+escape",
+				"command": "workbench.action.terminal.chat.close",
+				"when": "terminalChatFocus && terminalChatVisible"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.terminal.chat.close",
+				"when": "terminalChatFocus && terminalChatVisible"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "workbench.action.terminal.chat.focusInput",
+				"when": "terminalChatFocus && !inlineChatFocused"
+			},
+			{
+				"key": "ctrl+up",
+				"command": "workbench.action.terminal.chat.focusInput",
+				"when": "terminalChatFocus && !inlineChatFocused"
+			},
+			{
+				"key": "ctrl+down",
+				"command": "workbench.action.terminal.chat.focusResponse",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "ctrl+alt+enter",
+				"command": "workbench.action.terminal.chat.insertCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "alt+enter",
+				"command": "workbench.action.terminal.chat.insertCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "ctrl+alt+enter",
+				"command": "workbench.action.terminal.chat.insertFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
+			},
+			{
+				"key": "alt+enter",
+				"command": "workbench.action.terminal.chat.insertFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.terminal.chat.makeRequest",
+				"when": "terminalChatFocus && terminalHasBeenCreated && !inlineChatEmpty && !terminalChatActiveRequest || terminalChatFocus && terminalProcessSupported && !inlineChatEmpty && !terminalChatActiveRequest"
+			},
+			{
+				"key": "down",
+				"command": "workbench.action.terminal.chat.nextFromHistory",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "up",
+				"command": "workbench.action.terminal.chat.previousFromHistory",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.terminal.chat.runCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.terminal.chat.runFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
 			},
 			{
 				"key": "escape",
@@ -3709,7 +3931,7 @@
 			{
 				"key": "ctrl+space",
 				"command": "workbench.action.terminal.sendSequence",
-				"when": "config.terminal.integrated.shellIntegration.suggestEnabled && terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"when": "config.terminal.integrated.suggest.enabled && terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
 				"args": {
 					"text": "\u001b[24~e"
 				}
@@ -3793,17 +4015,17 @@
 			{
 				"key": "alt+c",
 				"command": "workbench.action.terminal.toggleFindCaseSensitive",
-				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "alt+r",
 				"command": "workbench.action.terminal.toggleFindRegex",
-				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "alt+w",
 				"command": "workbench.action.terminal.toggleFindWholeWord",
-				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+`",
@@ -3992,6 +4214,31 @@
 				"key": "escape",
 				"command": "breadcrumbs.selectEditor",
 				"when": "breadcrumbsActive && breadcrumbsVisible"
+			},
+			{
+				"key": "down",
+				"command": "notebook.cell.nullAction",
+				"when": "notebookOutputInputFocused"
+			},
+			{
+				"key": "up",
+				"command": "notebook.cell.nullAction",
+				"when": "notebookOutputInputFocused"
+			},
+			{
+				"key": "ctrl+a",
+				"command": "notebook.cell.output.selectAll",
+				"when": "notebookEditorFocused && notebookOutputFocused"
+			},
+			{
+				"key": "ctrl+pagedown",
+				"command": "notebook.focusNextEditor",
+				"when": "accessibilityModeEnabled && notebookCellEditorFocused"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "notebook.focusPreviousEditor",
+				"when": "accessibilityModeEnabled && notebookCellEditorFocused"
 			},
 			{
 				"key": "ctrl+k down",
@@ -4183,6 +4430,11 @@
 				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedFirstFocus && !inputFocus"
 			},
 			{
+				"key": "ctrl+enter",
+				"command": "inlineChat.acceptChanges",
+				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.mode != 'preview'"
+			},
+			{
 				"key": "end",
 				"command": "lastCompressedFolder",
 				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedLastFocus && !inputFocus"
@@ -4263,6 +4515,26 @@
 				"when": "notificationCenterVisible"
 			},
 			{
+				"key": "ctrl+alt+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
 				"key": "ctrl+alt+-",
 				"command": "workbench.action.quickInputBack",
 				"when": "inQuickOpen"
@@ -4323,16 +4595,6 @@
 				"when": "isDevelopment"
 			},
 			{
-				"key": "ctrl+k i",
-				"command": "inlineChat.quickVoice.start",
-				"when": "editorFocus && hasSpeechProvider && !inlineChat.quickChatInProgress"
-			},
-			{
-				"key": "ctrl+k i",
-				"command": "inlineChat.quickVoice.stop",
-				"when": "hasSpeechProvider && inlineChat.quickChatInProgress"
-			},
-			{
 				"key": "escape",
 				"command": "notifications.hideToasts",
 				"when": "notificationFocus && notificationToastsVisible"
@@ -4340,32 +4602,22 @@
 			{
 				"key": "escape",
 				"command": "workbench.action.chat.stopListening",
-				"when": "hasChatProvider && hasSpeechProvider && voiceChatInProgress"
+				"when": "voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || voiceChatInProgress && scopedVoiceChatInProgress == 'view'"
 			},
 			{
 				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInChatEditor",
-				"when": "hasChatProvider && hasSpeechProvider && voiceChatInEditorInProgress"
-			},
-			{
-				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInChatView",
-				"when": "hasChatProvider && hasSpeechProvider && voiceChatInViewInProgress"
-			},
-			{
-				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInInlineChat",
-				"when": "hasChatProvider && hasSpeechProvider && inlineVoiceChatInProgress"
-			},
-			{
-				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInQuickChat",
-				"when": "hasChatProvider && hasSpeechProvider && quickVoiceChatInProgress"
+				"command": "workbench.action.chat.stopReadChatItemAloud",
+				"when": "scopedChatSynthesisInProgress"
 			},
 			{
 				"key": "escape",
 				"command": "workbench.action.editorDictation.stop",
 				"when": "editorDictation.inProgress"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.speech.stopReadAloud",
+				"when": "scopedChatSynthesisInProgress && textToSpeechInProgress"
 			},
 			{
 				"key": "f10",
@@ -4423,6 +4675,16 @@
 				"when": "editorHasCallHierarchyProvider"
 			},
 			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.chat.insertCodeBlock",
+				"when": "accessibleViewInCodeBlock && chatIsEnabled || chatIsEnabled && inChat && !inChatInput"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "workbench.action.terminal.chat.start",
+				"when": "terminalChatAgentRegistered && terminalFocusInAny && terminalHasBeenCreated || terminalChatAgentRegistered && terminalFocusInAny && terminalProcessSupported"
+			},
+			{
 				"key": "ctrl+.",
 				"command": "acceptSelectedCodeAction",
 				"when": "codeActionMenuVisible"
@@ -4471,6 +4733,11 @@
 				"key": "escape",
 				"command": "diffEditor.exitCompareMove",
 				"when": "comparingMovedCode"
+			},
+			{
+				"key": "ctrl+space",
+				"command": "editor.action.inlineEdits.accept",
+				"when": "inlineEditsVisible"
 			}
 		]
 	}

--- a/mackeybindings/README.md
+++ b/mackeybindings/README.md
@@ -21,7 +21,7 @@
 
 Use Mac Keybindings on any OS
 
-Keybindings provided by https://github.com/h-jennings - Thank you!
+Keybindings provided by https://github.com/codebling/vs-code-default-keybindings - Thank you!
 
 This extension does not remove any existing bindings. On the same os as that of
 the keybindings that means everything will be bound twice. On other OS' that

--- a/mackeybindings/package.json
+++ b/mackeybindings/package.json
@@ -9,9 +9,9 @@
 	"icon": "Mac.png",
 	"license": "BSD-2-Clause-Patent",
 	"publisher": "fredhappyface",
-	"version": "1.40.1",
+	"version": "1.91.1",
 	"engines": {
-		"vscode": "^1.40.0"
+		"vscode": "^1.91.1"
 	},
 	"categories": [
 		"Keymaps"
@@ -24,9 +24,29 @@
 	"contributes": {
 		"keybindings": [
 			{
+				"key": "escape escape",
+				"command": "workbench.action.exitZenMode",
+				"when": "inZenMode"
+			},
+			{
 				"key": "shift+escape",
 				"command": "closeReferenceSearch",
 				"when": "inReferenceSearchEditor && !config.editor.stablePeek"
+			},
+			{
+				"key": "escape",
+				"command": "closeReferenceSearch",
+				"when": "inReferenceSearchEditor && !config.editor.stablePeek"
+			},
+			{
+				"key": "escape",
+				"command": "editor.closeTestPeek",
+				"when": "testing.isInPeek && !config.editor.stablePeek || testing.isPeekVisible && !config.editor.stablePeek"
+			},
+			{
+				"key": "shift+escape",
+				"command": "cancelSelection",
+				"when": "editorHasSelection && textInputFocus"
 			},
 			{
 				"key": "escape",
@@ -79,27 +99,54 @@
 				"when": "textInputFocus"
 			},
 			{
+				"key": "down",
+				"command": "cursorDown",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "shift+down",
+				"command": "cursorDownSelect",
+				"when": "textInputFocus"
+			},
+			{
 				"key": "cmd+right",
 				"command": "cursorEnd",
-				"when": "textInputFocus"
+				"when": "textInputFocus",
+				"args": {
+					"sticky": false
+				}
 			},
 			{
 				"key": "end",
 				"command": "cursorEnd",
-				"when": "textInputFocus"
+				"when": "textInputFocus",
+				"args": {
+					"sticky": false
+				}
 			},
 			{
 				"key": "shift+cmd+right",
 				"command": "cursorEndSelect",
-				"when": "textInputFocus"
+				"when": "textInputFocus",
+				"args": {
+					"sticky": false
+				}
 			},
 			{
 				"key": "shift+end",
 				"command": "cursorEndSelect",
-				"when": "textInputFocus"
+				"when": "textInputFocus",
+				"args": {
+					"sticky": false
+				}
 			},
 			{
 				"key": "cmd+left",
+				"command": "cursorHome",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "home",
 				"command": "cursorHome",
 				"when": "textInputFocus"
 			},
@@ -119,6 +166,11 @@
 				"when": "textInputFocus"
 			},
 			{
+				"key": "left",
+				"command": "cursorLeft",
+				"when": "textInputFocus"
+			},
+			{
 				"key": "shift+left",
 				"command": "cursorLeftSelect",
 				"when": "textInputFocus"
@@ -129,13 +181,33 @@
 				"when": "textInputFocus"
 			},
 			{
+				"key": "ctrl+shift+e",
+				"command": "cursorLineEndSelect",
+				"when": "textInputFocus"
+			},
+			{
 				"key": "ctrl+a",
 				"command": "cursorLineStart",
 				"when": "textInputFocus"
 			},
 			{
+				"key": "ctrl+shift+a",
+				"command": "cursorLineStartSelect",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "pagedown",
+				"command": "cursorPageDown",
+				"when": "textInputFocus"
+			},
+			{
 				"key": "shift+pagedown",
 				"command": "cursorPageDownSelect",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "pageup",
+				"command": "cursorPageUp",
 				"when": "textInputFocus"
 			},
 			{
@@ -145,6 +217,11 @@
 			},
 			{
 				"key": "ctrl+f",
+				"command": "cursorRight",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "right",
 				"command": "cursorRight",
 				"when": "textInputFocus"
 			},
@@ -169,6 +246,16 @@
 				"when": "textInputFocus"
 			},
 			{
+				"key": "up",
+				"command": "cursorUp",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "shift+up",
+				"command": "cursorUpSelect",
+				"when": "textInputFocus"
+			},
+			{
 				"key": "ctrl+backspace",
 				"command": "deleteLeft",
 				"when": "textInputFocus"
@@ -180,6 +267,11 @@
 			},
 			{
 				"key": "shift+backspace",
+				"command": "deleteLeft",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "backspace",
 				"command": "deleteLeft",
 				"when": "textInputFocus"
 			},
@@ -200,8 +292,7 @@
 			},
 			{
 				"key": "cmd+a",
-				"command": "editor.action.selectAll",
-				"when": "textInputFocus"
+				"command": "editor.action.selectAll"
 			},
 			{
 				"key": "cmd+c",
@@ -221,14 +312,28 @@
 				"when": "textInputFocus"
 			},
 			{
+				"key": "cmd+down",
+				"command": "inlineChat.arrowOutDown",
+				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatInnerCursorLast && !accessibilityModeEnabled && !isEmbeddedDiffEditor"
+			},
+			{
+				"key": "cmd+up",
+				"command": "inlineChat.arrowOutUp",
+				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatInnerCursorFirst && !accessibilityModeEnabled && !isEmbeddedDiffEditor"
+			},
+			{
 				"key": "ctrl+o",
 				"command": "lineBreakInsert",
 				"when": "textInputFocus && !editorReadonly"
 			},
 			{
+				"key": "shift+tab",
+				"command": "outdent",
+				"when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+			},
+			{
 				"key": "shift+cmd+z",
-				"command": "redo",
-				"when": "textInputFocus && !editorReadonly"
+				"command": "redo"
 			},
 			{
 				"key": "ctrl+pagedown",
@@ -251,13 +356,27 @@
 				"when": "textInputFocus"
 			},
 			{
+				"key": "tab",
+				"command": "tab",
+				"when": "editorTextFocus && !editorReadonly && !editorTabMovesFocus"
+			},
+			{
 				"key": "cmd+z",
-				"command": "undo",
-				"when": "textInputFocus && !editorReadonly"
+				"command": "undo"
+			},
+			{
+				"key": "shift+down",
+				"command": "cursorColumnSelectDown",
+				"when": "editorColumnSelection && textInputFocus"
 			},
 			{
 				"key": "shift+left",
 				"command": "cursorColumnSelectLeft",
+				"when": "editorColumnSelection && textInputFocus"
+			},
+			{
+				"key": "shift+pagedown",
+				"command": "cursorColumnSelectPageDown",
 				"when": "editorColumnSelection && textInputFocus"
 			},
 			{
@@ -266,9 +385,19 @@
 				"when": "editorColumnSelection && textInputFocus"
 			},
 			{
+				"key": "shift+right",
+				"command": "cursorColumnSelectRight",
+				"when": "editorColumnSelection && textInputFocus"
+			},
+			{
 				"key": "shift+up",
 				"command": "cursorColumnSelectUp",
 				"when": "editorColumnSelection && textInputFocus"
+			},
+			{
+				"key": "shift+escape",
+				"command": "removeSecondaryCursors",
+				"when": "editorHasMultipleSelections && textInputFocus"
 			},
 			{
 				"key": "escape",
@@ -276,8 +405,63 @@
 				"when": "editorHasMultipleSelections && textInputFocus"
 			},
 			{
+				"key": "cmd+down",
+				"command": "notebook.cell.chat.arrowOutDown",
+				"when": "inlineChatFocused && inlineChatInnerCursorLast && notebookCellChatFocused && !accessibilityModeEnabled && !notebookCellEditorFocused"
+			},
+			{
+				"key": "cmd+up",
+				"command": "notebook.cell.chat.arrowOutUp",
+				"when": "inlineChatFocused && inlineChatInnerCursorFirst && notebookCellChatFocused && !accessibilityModeEnabled && !notebookCellEditorFocused"
+			},
+			{
+				"key": "cmd+up",
+				"command": "notebook.cell.focusChatWidget",
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && notebookEditorCursorAtBoundary != 'bottom' && notebookEditorCursorAtBoundary != 'none'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "notebook.cell.focusNextChatWidget",
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && notebookEditorCursorAtBoundary != 'none' && notebookEditorCursorAtBoundary != 'top'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "inlineChat.focus",
+				"when": "editorTextFocus && inlineChatVisible && !accessibilityModeEnabled && !inlineChatFocused && !isEmbeddedDiffEditor && inlineChatOuterCursorPosition == 'above'"
+			},
+			{
+				"key": "cmd+up",
+				"command": "inlineChat.focus",
+				"when": "editorTextFocus && inlineChatVisible && !accessibilityModeEnabled && !inlineChatFocused && !isEmbeddedDiffEditor && inlineChatOuterCursorPosition == 'below'"
+			},
+			{
+				"key": "escape",
+				"command": "notebook.cell.chat.acceptChanges",
+				"when": "inlineChatFocused && notebookCellChatFocused && notebookChatUserDidEdit && !notebookCellEditorFocused"
+			},
+			{
+				"key": "down",
+				"command": "notebook.cell.chat.nextFromHistory",
+				"when": "inlineChatFocused && notebookCellChatFocused"
+			},
+			{
+				"key": "up",
+				"command": "notebook.cell.chat.previousFromHistory",
+				"when": "inlineChatFocused && notebookCellChatFocused"
+			},
+			{
+				"key": "f12",
+				"command": "goToNextReference",
+				"when": "inReferenceSearchEditor || referenceSearchVisible"
+			},
+			{
 				"key": "f4",
 				"command": "goToNextReference",
+				"when": "inReferenceSearchEditor || referenceSearchVisible"
+			},
+			{
+				"key": "shift+f12",
+				"command": "goToPreviousReference",
 				"when": "inReferenceSearchEditor || referenceSearchVisible"
 			},
 			{
@@ -286,15 +470,61 @@
 				"when": "inReferenceSearchEditor || referenceSearchVisible"
 			},
 			{
+				"key": "cmd+enter",
+				"command": "refactorPreview.apply",
+				"when": "refactorPreview.enabled && refactorPreview.hasCheckedChanges && focusedView == 'refactorPreview'"
+			},
+			{
+				"key": "alt+enter",
+				"command": "testing.editFocusedTest",
+				"when": "focusedView == 'workbench.view.testing'"
+			},
+			{
+				"key": "escape",
+				"command": "notebook.cell.quitEdit",
+				"when": "inputFocus && notebookEditorFocused && !editorHasMultipleSelections && !editorHasSelection && !editorHoverVisible && !inlineChatFocused"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "notebook.cell.quitEdit",
+				"when": "inputFocus && notebookEditorFocused && !inlineChatFocused && notebookCellType == 'markup'"
+			},
+			{
+				"key": "escape",
+				"command": "inlineChat.discard",
+				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatUserDidEdit"
+			},
+			{
 				"key": "cmd+f",
-				"command": "actions.find"
+				"command": "actions.find",
+				"when": "editorFocus || editorIsOpen"
 			},
 			{
 				"key": "cmd+e",
 				"command": "actions.findWithSelection"
 			},
 			{
+				"key": "enter",
+				"command": "breakpointWidget.action.acceptInput",
+				"when": "breakpointWidgetVisible && inBreakpointWidget"
+			},
+			{
+				"key": "cmd+up",
+				"command": "chat.action.focus",
+				"when": "chatCursorAtTop && inChatInput && chatLocation == 'panel'"
+			},
+			{
+				"key": "cmd+up",
+				"command": "chat.action.focus",
+				"when": "inChatInput && isLinux && chatLocation == 'panel' || inChatInput && isWindows && chatLocation == 'panel'"
+			},
+			{
 				"key": "shift+escape",
+				"command": "closeBreakpointWidget",
+				"when": "breakpointWidgetVisible && textInputFocus"
+			},
+			{
+				"key": "escape",
 				"command": "closeBreakpointWidget",
 				"when": "breakpointWidgetVisible && textInputFocus"
 			},
@@ -311,6 +541,16 @@
 			{
 				"key": "shift+alt+right",
 				"command": "cursorWordEndRightSelect",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "alt+left",
+				"command": "cursorWordLeft",
+				"when": "textInputFocus"
+			},
+			{
+				"key": "shift+alt+left",
+				"command": "cursorWordLeftSelect",
 				"when": "textInputFocus"
 			},
 			{
@@ -331,16 +571,6 @@
 			{
 				"key": "ctrl+shift+alt+right",
 				"command": "cursorWordPartRightSelect",
-				"when": "textInputFocus"
-			},
-			{
-				"key": "alt+left",
-				"command": "cursorWordStartLeft",
-				"when": "textInputFocus"
-			},
-			{
-				"key": "shift+alt+left",
-				"command": "cursorWordStartLeftSelect",
 				"when": "textInputFocus"
 			},
 			{
@@ -379,6 +609,16 @@
 				"when": "textInputFocus && !editorReadonly"
 			},
 			{
+				"key": "f7",
+				"command": "editor.action.accessibleDiffViewer.next",
+				"when": "isInDiffEditor"
+			},
+			{
+				"key": "shift+f7",
+				"command": "editor.action.accessibleDiffViewer.prev",
+				"when": "isInDiffEditor"
+			},
+			{
 				"key": "cmd+k cmd+c",
 				"command": "editor.action.addCommentLine",
 				"when": "editorTextFocus && !editorReadonly"
@@ -391,7 +631,7 @@
 			{
 				"key": "alt+cmd+.",
 				"command": "editor.action.autoFix",
-				"when": "editorTextFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)quickfix\\b/"
+				"when": "textInputFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)quickfix\\b/"
 			},
 			{
 				"key": "shift+alt+a",
@@ -399,24 +639,26 @@
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
+				"key": "escape",
+				"command": "editor.action.cancelSelectionAnchor",
+				"when": "editorTextFocus && selectionAnchorSet"
+			},
+			{
 				"key": "cmd+f2",
 				"command": "editor.action.changeAll",
-				"when": "editorTextFocus && editorTextFocus && !editorReadonly"
+				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
 				"key": "cmd+c",
-				"command": "editor.action.clipboardCopyAction",
-				"when": "textInputFocus"
+				"command": "editor.action.clipboardCopyAction"
 			},
 			{
 				"key": "cmd+x",
-				"command": "editor.action.clipboardCutAction",
-				"when": "textInputFocus && !editorReadonly"
+				"command": "editor.action.clipboardCutAction"
 			},
 			{
 				"key": "cmd+v",
-				"command": "editor.action.clipboardPasteAction",
-				"when": "textInputFocus && !editorReadonly"
+				"command": "editor.action.clipboardPasteAction"
 			},
 			{
 				"key": "cmd+/",
@@ -434,34 +676,24 @@
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
-				"key": "shift+cmd+z",
-				"command": "editor.action.customEditor.redo",
-				"when": "focusedCustomEditorIsEditable && !inputFocus"
-			},
-			{
-				"key": "cmd+z",
-				"command": "editor.action.customEditor.undo",
-				"when": "focusedCustomEditorIsEditable && !inputFocus"
-			},
-			{
-				"key": "cmd+k cmd+k",
-				"command": "editor.action.defineKeybinding",
-				"when": "editorTextFocus && !editorReadonly && editorLangId == 'jsonc'"
-			},
-			{
 				"key": "shift+cmd+k",
 				"command": "editor.action.deleteLines",
 				"when": "textInputFocus && !editorReadonly"
 			},
 			{
-				"key": "shift+f7",
-				"command": "editor.action.diffReview.prev",
-				"when": "isInDiffEditor"
+				"key": "alt+f3",
+				"command": "editor.action.dirtydiff.next",
+				"when": "editorTextFocus && !textCompareEditorActive"
 			},
 			{
 				"key": "shift+alt+f3",
 				"command": "editor.action.dirtydiff.previous",
-				"when": "editorTextFocus"
+				"when": "editorTextFocus && !textCompareEditorActive"
+			},
+			{
+				"key": "enter",
+				"command": "editor.action.extensioneditor.findNext",
+				"when": "webviewFindWidgetFocused && !editorFocus && activeEditor == 'workbench.editor.extension'"
 			},
 			{
 				"key": "shift+enter",
@@ -476,22 +708,57 @@
 			{
 				"key": "shift+alt+f",
 				"command": "editor.action.formatDocument",
-				"when": "editorHasDocumentFormattingProvider && editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly"
+				"when": "editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly && !inCompositeEditor"
 			},
 			{
 				"key": "shift+alt+f",
 				"command": "editor.action.formatDocument.none",
-				"when": "editorTextFocus && !editorHasDocumentFormattingProvider && !editorHasDocumentFormattingProvider && !editorReadonly"
+				"when": "editorTextFocus && !editorHasDocumentFormattingProvider && !editorReadonly"
 			},
 			{
 				"key": "cmd+k cmd+f",
 				"command": "editor.action.formatSelection",
-				"when": "editorHasDocumentSelectionFormattingProvider && editorHasDocumentSelectionFormattingProvider && editorTextFocus && !editorReadonly"
+				"when": "editorHasDocumentSelectionFormattingProvider && editorTextFocus && !editorReadonly"
+			},
+			{
+				"key": "cmd+down",
+				"command": "editor.action.goToBottomHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "end",
+				"command": "editor.action.goToBottomHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "enter",
+				"command": "editor.action.goToFocusedStickyScrollLine",
+				"when": "stickyScrollFocused"
 			},
 			{
 				"key": "cmd+f12",
 				"command": "editor.action.goToImplementation",
-				"when": "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+				"when": "editorHasImplementationProvider && editorTextFocus"
+			},
+			{
+				"key": "shift+f12",
+				"command": "editor.action.goToReferences",
+				"when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+			},
+			{
+				"key": "cmd+up",
+				"command": "editor.action.goToTopHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "home",
+				"command": "editor.action.goToTopHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "escape",
+				"command": "editor.action.hideColorPicker",
+				"when": "standaloneColorPickerVisible"
 			},
 			{
 				"key": "shift+cmd+.",
@@ -509,8 +776,53 @@
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
+				"key": "escape",
+				"command": "editor.action.inlineEdit.reject",
+				"when": "inlineEditVisible && !editorReadonly"
+			},
+			{
+				"key": "escape",
+				"command": "editor.action.inlineEdits.hide",
+				"when": "inlineEditsVisible"
+			},
+			{
+				"key": "alt+]",
+				"command": "editor.action.inlineEdits.showNext",
+				"when": "inlineEditsVisible && !editorReadonly"
+			},
+			{
+				"key": "alt+[",
+				"command": "editor.action.inlineEdits.showPrevious",
+				"when": "inlineEditsVisible && !editorReadonly"
+			},
+			{
+				"key": "escape",
+				"command": "editor.action.inlineSuggest.hide",
+				"when": "inlineSuggestionVisible"
+			},
+			{
+				"key": "alt+]",
+				"command": "editor.action.inlineSuggest.showNext",
+				"when": "inlineSuggestionVisible && !editorReadonly"
+			},
+			{
+				"key": "alt+[",
+				"command": "editor.action.inlineSuggest.showPrevious",
+				"when": "inlineSuggestionVisible && !editorReadonly"
+			},
+			{
+				"key": "enter",
+				"command": "editor.action.insertColorWithStandaloneColorPicker",
+				"when": "standaloneColorPickerFocused"
+			},
+			{
 				"key": "alt+cmd+up",
 				"command": "editor.action.insertCursorAbove",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "shift+alt+i",
+				"command": "editor.action.insertCursorAtEndOfEachLineSelected",
 				"when": "editorTextFocus"
 			},
 			{
@@ -539,24 +851,34 @@
 				"when": "editorTextFocus"
 			},
 			{
+				"key": "shift+cmd+f2",
+				"command": "editor.action.linkedEditing",
+				"when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+			},
+			{
 				"key": "alt+f8",
 				"command": "editor.action.marker.next",
-				"when": "editorFocus && !editorReadonly"
+				"when": "editorFocus"
 			},
 			{
 				"key": "f8",
 				"command": "editor.action.marker.nextInFiles",
-				"when": "editorFocus && !editorReadonly"
+				"when": "editorFocus"
 			},
 			{
 				"key": "shift+alt+f8",
 				"command": "editor.action.marker.prev",
-				"when": "editorFocus && !editorReadonly"
+				"when": "editorFocus"
 			},
 			{
 				"key": "shift+f8",
 				"command": "editor.action.marker.prevInFiles",
-				"when": "editorFocus && !editorReadonly"
+				"when": "editorFocus"
+			},
+			{
+				"key": "alt+down",
+				"command": "editor.action.moveLinesDownAction",
+				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
 				"key": "alt+up",
@@ -566,6 +888,20 @@
 			{
 				"key": "cmd+k cmd+d",
 				"command": "editor.action.moveSelectionToNextFindMatch",
+				"when": "editorFocus"
+			},
+			{
+				"key": "alt+f9",
+				"command": "editor.action.nextCommentThreadAction"
+			},
+			{
+				"key": "cmd+k alt+cmd+down",
+				"command": "editor.action.nextCommentingRange",
+				"when": "accessibilityModeEnabled && commentFocused || accessibilityModeEnabled && editorFocus || accessibilityHelpIsShown && accessibilityModeEnabled && accessibleViewCurrentProviderId == 'comments'"
+			},
+			{
+				"key": "f3",
+				"command": "editor.action.nextMatchFindAction",
 				"when": "editorFocus"
 			},
 			{
@@ -584,9 +920,34 @@
 				"when": "editorFocus"
 			},
 			{
+				"key": "shift+alt+o",
+				"command": "editor.action.organizeImports",
+				"when": "textInputFocus && !editorReadonly && supportedCodeAction =~ /(\\s|^)source\\.organizeImports\\b/"
+			},
+			{
 				"key": "cmd+[",
 				"command": "editor.action.outdentLines",
 				"when": "editorTextFocus && !editorReadonly"
+			},
+			{
+				"key": "alt+down",
+				"command": "editor.action.pageDownHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "pagedown",
+				"command": "editor.action.pageDownHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "alt+up",
+				"command": "editor.action.pageUpHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "pageup",
+				"command": "editor.action.pageUpHover",
+				"when": "editorHoverFocused"
 			},
 			{
 				"key": "alt+f12",
@@ -597,6 +958,20 @@
 				"key": "shift+cmd+f12",
 				"command": "editor.action.peekImplementation",
 				"when": "editorHasImplementationProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+			},
+			{
+				"key": "shift+alt+f9",
+				"command": "editor.action.previousCommentThreadAction"
+			},
+			{
+				"key": "cmd+k alt+cmd+up",
+				"command": "editor.action.previousCommentingRange",
+				"when": "accessibilityModeEnabled && commentFocused || accessibilityModeEnabled && editorFocus || accessibilityHelpIsShown && accessibilityModeEnabled && accessibleViewCurrentProviderId == 'comments'"
+			},
+			{
+				"key": "shift+f3",
+				"command": "editor.action.previousMatchFindAction",
+				"when": "editorFocus"
 			},
 			{
 				"key": "shift+cmd+g",
@@ -616,7 +991,17 @@
 			{
 				"key": "cmd+.",
 				"command": "editor.action.quickFix",
-				"when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+				"when": "editorHasCodeActionsProvider && textInputFocus && !editorReadonly"
+			},
+			{
+				"key": "ctrl+shift+r",
+				"command": "editor.action.refactor",
+				"when": "editorHasCodeActionsProvider && textInputFocus && !editorReadonly"
+			},
+			{
+				"key": "alt+cmd+backspace",
+				"command": "editor.action.removeBrackets",
+				"when": "editorTextFocus"
 			},
 			{
 				"key": "cmd+k cmd+u",
@@ -624,9 +1009,19 @@
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
+				"key": "f2",
+				"command": "editor.action.rename",
+				"when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+			},
+			{
 				"key": "f12",
 				"command": "editor.action.revealDefinition",
-				"when": "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
+				"when": "editorHasDefinitionProvider && editorTextFocus"
+			},
+			{
+				"key": "cmd+f12",
+				"command": "editor.action.revealDefinition",
+				"when": "editorHasDefinitionProvider && editorTextFocus && isWeb"
 			},
 			{
 				"key": "cmd+k f12",
@@ -634,14 +1029,64 @@
 				"when": "editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor"
 			},
 			{
+				"key": "cmd+k cmd+f12",
+				"command": "editor.action.revealDefinitionAside",
+				"when": "editorHasDefinitionProvider && editorTextFocus && isWeb && !isInEmbeddedEditor"
+			},
+			{
+				"key": "down",
+				"command": "editor.action.scrollDownHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "left",
+				"command": "editor.action.scrollLeftHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "right",
+				"command": "editor.action.scrollRightHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "up",
+				"command": "editor.action.scrollUpHover",
+				"when": "editorHoverFocused"
+			},
+			{
+				"key": "escape",
+				"command": "editor.action.selectEditor",
+				"when": "stickyScrollFocused"
+			},
+			{
+				"key": "cmd+k cmd+k",
+				"command": "editor.action.selectFromAnchorToCursor",
+				"when": "editorTextFocus && selectionAnchorSet"
+			},
+			{
 				"key": "shift+cmd+l",
 				"command": "editor.action.selectHighlights",
 				"when": "editorFocus"
 			},
 			{
-				"key": "alt+f1",
-				"command": "editor.action.showAccessibilityHelp",
-				"when": "editorFocus"
+				"key": "down",
+				"command": "editor.action.selectNextStickyScrollLine",
+				"when": "stickyScrollFocused"
+			},
+			{
+				"key": "up",
+				"command": "editor.action.selectPreviousStickyScrollLine",
+				"when": "stickyScrollFocused"
+			},
+			{
+				"key": "cmd+k cmd+b",
+				"command": "editor.action.setSelectionAnchor",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "shift+f10",
+				"command": "editor.action.showContextMenu",
+				"when": "textInputFocus"
 			},
 			{
 				"key": "cmd+k cmd+i",
@@ -670,11 +1115,21 @@
 			},
 			{
 				"key": "alt+cmd+f",
-				"command": "editor.action.startFindReplaceAction"
+				"command": "editor.action.startFindReplaceAction",
+				"when": "editorFocus || editorIsOpen"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "editor.action.submitComment",
+				"when": "commentEditorFocused"
 			},
 			{
 				"key": "ctrl+shift+m",
 				"command": "editor.action.toggleTabFocusMode"
+			},
+			{
+				"key": "alt+z",
+				"command": "editor.action.toggleWordWrap"
 			},
 			{
 				"key": "ctrl+t",
@@ -687,9 +1142,19 @@
 				"when": "editorHasSignatureHelpProvider && editorTextFocus"
 			},
 			{
+				"key": "cmd+i",
+				"command": "editor.action.triggerSuggest",
+				"when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly && !suggestWidgetVisible"
+			},
+			{
 				"key": "alt+escape",
 				"command": "editor.action.triggerSuggest",
-				"when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly"
+				"when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly && !suggestWidgetVisible"
+			},
+			{
+				"key": "ctrl+space",
+				"command": "editor.action.triggerSuggest",
+				"when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly && !suggestWidgetVisible"
 			},
 			{
 				"key": "cmd+k cmd+x",
@@ -697,14 +1162,9 @@
 				"when": "editorTextFocus && !editorReadonly"
 			},
 			{
-				"key": "cmd+c",
-				"command": "editor.action.webvieweditor.copy",
-				"when": "!editorFocus && !inputFocus && activeEditor == 'WebviewEditor'"
-			},
-			{
-				"key": "cmd+x",
-				"command": "editor.action.webvieweditor.cut",
-				"when": "!editorFocus && !inputFocus && activeEditor == 'WebviewEditor'"
+				"key": "enter",
+				"command": "editor.action.webvieweditor.findNext",
+				"when": "webviewFindWidgetFocused && !editorFocus && activeEditor == 'WebviewEditor'"
 			},
 			{
 				"key": "shift+enter",
@@ -712,34 +1172,49 @@
 				"when": "webviewFindWidgetFocused && !editorFocus && activeEditor == 'WebviewEditor'"
 			},
 			{
-				"key": "cmd+v",
-				"command": "editor.action.webvieweditor.paste",
-				"when": "!editorFocus && !inputFocus && activeEditor == 'WebviewEditor'"
-			},
-			{
-				"key": "shift+cmd+z",
-				"command": "editor.action.webvieweditor.redo",
-				"when": "!editorFocus && !inputFocus && !webviewHasOwnEditFunctions && activeEditor == 'WebviewEditor'"
-			},
-			{
-				"key": "cmd+a",
-				"command": "editor.action.webvieweditor.selectAll",
-				"when": "!editorFocus && !inputFocus && activeEditor == 'WebviewEditor'"
+				"key": "escape",
+				"command": "editor.action.webvieweditor.hideFind",
+				"when": "webviewFindWidgetVisible && !editorFocus && activeEditor == 'WebviewEditor'"
 			},
 			{
 				"key": "cmd+f",
 				"command": "editor.action.webvieweditor.showFind",
-				"when": "!editorFocus && activeEditor == 'WebviewEditor'"
+				"when": "webviewFindWidgetEnabled && !editorFocus && activeEditor == 'WebviewEditor'"
 			},
 			{
-				"key": "cmd+z",
-				"command": "editor.action.webvieweditor.undo",
-				"when": "!editorFocus && !inputFocus && !webviewHasOwnEditFunctions && activeEditor == 'WebviewEditor'"
+				"key": "f7",
+				"command": "editor.action.wordHighlight.next",
+				"when": "editorTextFocus && hasWordHighlights"
 			},
 			{
 				"key": "shift+f7",
 				"command": "editor.action.wordHighlight.prev",
 				"when": "editorTextFocus && hasWordHighlights"
+			},
+			{
+				"key": "escape",
+				"command": "editor.cancelOperation",
+				"when": "cancellableOperation"
+			},
+			{
+				"key": "cmd+.",
+				"command": "editor.changeDropType",
+				"when": "dropWidgetVisible"
+			},
+			{
+				"key": "cmd+.",
+				"command": "editor.changePasteType",
+				"when": "pasteWidgetVisible"
+			},
+			{
+				"key": "cmd+k cmd+,",
+				"command": "editor.createFoldingRangeFromSelection",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
+				"key": "escape",
+				"command": "editor.debug.action.closeExceptionWidget",
+				"when": "exceptionWidgetVisible"
 			},
 			{
 				"key": "cmd+k cmd+i",
@@ -749,7 +1224,12 @@
 			{
 				"key": "f9",
 				"command": "editor.debug.action.toggleBreakpoint",
-				"when": "editorTextFocus"
+				"when": "debuggersAvailable && disassemblyViewFocus || debuggersAvailable && editorTextFocus"
+			},
+			{
+				"key": "tab",
+				"command": "editor.emmet.action.expandAbbreviation",
+				"when": "config.emmet.triggerExpansionOnTab && editorTextFocus && !editorReadonly && !editorTabMovesFocus"
 			},
 			{
 				"key": "alt+cmd+[",
@@ -764,6 +1244,11 @@
 			{
 				"key": "cmd+k cmd+/",
 				"command": "editor.foldAllBlockComments",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
+				"key": "cmd+k cmd+-",
+				"command": "editor.foldAllExcept",
 				"when": "editorTextFocus && foldingEnabled"
 			},
 			{
@@ -812,13 +1297,38 @@
 				"when": "editorTextFocus && foldingEnabled"
 			},
 			{
+				"key": "f12",
+				"command": "editor.gotoNextSymbolFromResult",
+				"when": "hasSymbols"
+			},
+			{
 				"key": "escape",
 				"command": "editor.gotoNextSymbolFromResult.cancel",
 				"when": "hasSymbols"
 			},
 			{
+				"key": "escape",
+				"command": "editor.hideDropWidget",
+				"when": "dropWidgetVisible"
+			},
+			{
+				"key": "escape",
+				"command": "editor.hidePasteWidget",
+				"when": "pasteWidgetVisible"
+			},
+			{
+				"key": "cmd+k cmd+.",
+				"command": "editor.removeManualFoldingRanges",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
 				"key": "cmd+k cmd+l",
 				"command": "editor.toggleFold",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
+				"key": "cmd+k shift+cmd+l",
+				"command": "editor.toggleFoldRecursively",
 				"when": "editorTextFocus && foldingEnabled"
 			},
 			{
@@ -832,6 +1342,11 @@
 				"when": "editorTextFocus && foldingEnabled"
 			},
 			{
+				"key": "cmd+k cmd+=",
+				"command": "editor.unfoldAllExcept",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
 				"key": "cmd+k cmd+9",
 				"command": "editor.unfoldAllMarkerRegions",
 				"when": "editorTextFocus && foldingEnabled"
@@ -840,6 +1355,96 @@
 				"key": "cmd+k cmd+]",
 				"command": "editor.unfoldRecursively",
 				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
+				"key": "escape",
+				"command": "inlayHints.stopReadingLineWithHint",
+				"when": "isReadingLineWithInlayHints"
+			},
+			{
+				"key": "tab",
+				"command": "insertSnippet",
+				"when": "editorTextFocus && hasSnippetCompletions && !editorTabMovesFocus && !inSnippetMode"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "interactive.execute",
+				"when": "activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "shift+enter",
+				"command": "interactive.execute",
+				"when": "config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "enter",
+				"command": "interactive.execute",
+				"when": "!config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "escape",
+				"command": "notebook.cell.chat.discard",
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused && !notebookChatUserDidEdit"
+			},
+			{
+				"key": "pagedown",
+				"command": "notebook.cell.cursorPageDown",
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused"
+			},
+			{
+				"key": "shift+pagedown",
+				"command": "notebook.cell.cursorPageDownSelect",
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused"
+			},
+			{
+				"key": "pageup",
+				"command": "notebook.cell.cursorPageUp",
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused"
+			},
+			{
+				"key": "shift+pageup",
+				"command": "notebook.cell.cursorPageUpSelect",
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "notebook.cell.execute",
+				"when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || !notebookCellExecuting && notebookCellType == 'code' && notebookCellListFocused || inlineChatFocused && notebookCellChatFocused && notebookKernelCount > 0 || !notebookCellExecuting && notebookCellType == 'code' && notebookCellListFocused || inlineChatFocused && notebookCellChatFocused && notebookKernelSourceCount > 0 || inlineChatFocused && notebookCellChatFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code'"
+			},
+			{
+				"key": "alt+enter",
+				"command": "notebook.cell.executeAndInsertBelow",
+				"when": "notebookCellListFocused && notebookCellType == 'markup' || notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+			},
+			{
+				"key": "shift+enter",
+				"command": "notebook.cell.executeAndSelectBelow",
+				"when": "notebookCellListFocused && !inlineChatFocused && notebookCellType == 'markup' || notebookCellListFocused && notebookMissingKernelExtension && !inlineChatFocused && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !inlineChatFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !inlineChatFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+			},
+			{
+				"key": "shift+cmd+v",
+				"command": "notebook.cell.pasteAbove",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "down",
+				"command": "notebook.focusNextEditor",
+				"when": "config.notebook.navigation.allowNavigateToSurroundingCells && editorTextFocus && inputFocus && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && notebookEditorCursorAtBoundary != 'none' && notebookEditorCursorAtBoundary != 'top'"
+			},
+			{
+				"key": "up",
+				"command": "notebook.focusPreviousEditor",
+				"when": "config.notebook.navigation.allowNavigateToSurroundingCells && editorTextFocus && inputFocus && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && notebookEditorCursorAtBoundary != 'bottom' && notebookEditorCursorAtBoundary != 'none'"
+			},
+			{
+				"key": "shift+alt+f",
+				"command": "notebook.formatCell",
+				"when": "editorHasDocumentFormattingProvider && editorTextFocus && inCompositeEditor && notebookEditable && !editorReadonly && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "openReferenceToSide",
+				"when": "listFocus && referenceSearchVisible && !inputFocus && !treeElementCanCollapse && !treeElementCanExpand && !treestickyScrollFocused"
 			},
 			{
 				"key": "enter",
@@ -852,19 +1457,29 @@
 				"when": "inDebugRepl && textInputFocus"
 			},
 			{
+				"key": "shift+cmd+r",
+				"command": "rerunSearchEditorSearch",
+				"when": "inSearchEditor"
+			},
+			{
+				"key": "escape",
+				"command": "search.action.focusQueryEditorWidget",
+				"when": "inSearchEditor"
+			},
+			{
+				"key": "shift+cmd+backspace",
+				"command": "search.searchEditor.action.deleteFileResults",
+				"when": "inSearchEditor"
+			},
+			{
 				"key": "escape",
 				"command": "settings.action.clearSearchResults",
-				"when": "inSettingsSearch"
+				"when": "inSettingsEditor && inSettingsSearch"
 			},
 			{
-				"key": "cmd+.",
-				"command": "settings.action.editFocusedSetting",
-				"when": "inSettingsSearch"
-			},
-			{
-				"key": "shift+enter",
-				"command": "settings.action.focusPreviousSetting",
-				"when": "inSettingsSearch"
+				"key": "down",
+				"command": "settings.action.focusSettingsFile",
+				"when": "inSettingsSearch && !suggestWidgetVisible"
 			},
 			{
 				"key": "cmd+f",
@@ -882,9 +1497,48 @@
 				"when": "inReferenceSearchEditor || referenceSearchVisible"
 			},
 			{
+				"key": "escape",
+				"command": "welcome.goBack",
+				"when": "inWelcome && activeEditor == 'gettingStartedPage'"
+			},
+			{
+				"key": "cmd+k alt+cmd+c",
+				"command": "workbench.action.addComment"
+			},
+			{
+				"key": "cmd+/",
+				"command": "workbench.action.chat.attachContext",
+				"when": "inChatInput"
+			},
+			{
+				"key": "ctrl+alt+enter",
+				"command": "workbench.action.chat.runInTerminal",
+				"when": "accessibleViewInCodeBlock && chatIsEnabled || chatIsEnabled && inChat"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.chat.submit",
+				"when": "chatInputHasText && inChatInput && !chatSessionRequestInProgress"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "workbench.action.chat.submitSecondaryAgent",
+				"when": "chatInputHasText && inChatInput && !chatInputHasAgent && !chatSessionRequestInProgress"
+			},
+			{
+				"key": "alt+f5",
+				"command": "workbench.action.editor.nextChange",
+				"when": "editorTextFocus && !textCompareEditorActive"
+			},
+			{
 				"key": "shift+alt+f5",
 				"command": "workbench.action.editor.previousChange",
-				"when": "editorTextFocus"
+				"when": "editorTextFocus && !textCompareEditorActive"
+			},
+			{
+				"key": "shift+escape",
+				"command": "workbench.action.hideComment",
+				"when": "commentEditorFocused"
 			},
 			{
 				"key": "escape",
@@ -892,19 +1546,44 @@
 				"when": "commentEditorFocused"
 			},
 			{
-				"key": "cmd+enter",
-				"command": "workbench.action.submitComment",
-				"when": "commentEditorFocused"
+				"key": "tab",
+				"command": "editor.action.inlineEdit.accept",
+				"when": "cursorAtInlineEdit && inlineEditVisible && !editorReadonly"
+			},
+			{
+				"key": "alt+cmd+=",
+				"command": "editor.action.inlineEdit.jumpTo",
+				"when": "inlineEditVisible && !cursorAtInlineEdit && !editorReadonly"
+			},
+			{
+				"key": "alt+cmd+=",
+				"command": "editor.action.inlineEdit.trigger",
+				"when": "!editorReadonly && !inlineEditVisible"
+			},
+			{
+				"key": "cmd+right",
+				"command": "editor.action.inlineSuggest.acceptNextWord",
+				"when": "inlineSuggestionVisible && !editorReadonly"
+			},
+			{
+				"key": "alt+f8",
+				"command": "testing.goToNextMessage",
+				"when": "editorFocus && testing.isPeekVisible"
+			},
+			{
+				"key": "shift+alt+f8",
+				"command": "testing.goToPreviousMessage",
+				"when": "editorFocus && testing.isPeekVisible"
 			},
 			{
 				"key": "shift+escape",
 				"command": "closeFindWidget",
-				"when": "editorFocus && findWidgetVisible"
+				"when": "editorFocus && findWidgetVisible && !isComposing"
 			},
 			{
 				"key": "escape",
 				"command": "closeFindWidget",
-				"when": "editorFocus && findWidgetVisible"
+				"when": "editorFocus && findWidgetVisible && !isComposing"
 			},
 			{
 				"key": "alt+cmd+enter",
@@ -920,6 +1599,11 @@
 				"key": "shift+cmd+1",
 				"command": "editor.action.replaceOne",
 				"when": "editorFocus && findWidgetVisible"
+			},
+			{
+				"key": "enter",
+				"command": "editor.action.replaceOne",
+				"when": "editorFocus && findWidgetVisible && replaceInputFocussed"
 			},
 			{
 				"key": "alt+enter",
@@ -947,17 +1631,52 @@
 				"when": "editorFocus"
 			},
 			{
+				"key": "alt+cmd+p",
+				"command": "togglePreserveCase",
+				"when": "editorFocus"
+			},
+			{
+				"key": "alt+cmd+=",
+				"command": "editor.action.inlineEdit.jumpBack",
+				"when": "cursorAtInlineEdit && !editorReadonly"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "notebook.cell.chat.acceptChanges",
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused"
+			},
+			{
+				"key": "tab",
+				"command": "jumpToNextSnippetPlaceholder",
+				"when": "hasNextTabstop && inSnippetMode && textInputFocus"
+			},
+			{
 				"key": "shift+tab",
 				"command": "jumpToPrevSnippetPlaceholder",
-				"when": "editorTextFocus && hasPrevTabstop && inSnippetMode"
+				"when": "hasPrevTabstop && inSnippetMode && textInputFocus"
+			},
+			{
+				"key": "escape",
+				"command": "leaveEditorMessage",
+				"when": "messageVisible"
 			},
 			{
 				"key": "shift+escape",
 				"command": "leaveSnippet",
-				"when": "editorTextFocus && inSnippetMode"
+				"when": "inSnippetMode && textInputFocus"
+			},
+			{
+				"key": "escape",
+				"command": "leaveSnippet",
+				"when": "inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "shift+escape",
+				"command": "closeDirtyDiff",
+				"when": "dirtyDiffVisible"
+			},
+			{
+				"key": "escape",
 				"command": "closeDirtyDiff",
 				"when": "dirtyDiffVisible"
 			},
@@ -968,11 +1687,31 @@
 			},
 			{
 				"key": "escape",
+				"command": "closeMarkersNavigation",
+				"when": "editorFocus && markersNavigationVisible"
+			},
+			{
+				"key": "escape",
+				"command": "notifications.hideToasts",
+				"when": "notificationToastsVisible"
+			},
+			{
+				"key": "shift+escape",
+				"command": "closeParameterHints",
+				"when": "editorFocus && parameterHintsVisible"
+			},
+			{
+				"key": "escape",
 				"command": "closeParameterHints",
 				"when": "editorFocus && parameterHintsVisible"
 			},
 			{
 				"key": "ctrl+n",
+				"command": "showNextParameterHint",
+				"when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+			},
+			{
+				"key": "alt+down",
 				"command": "showNextParameterHint",
 				"when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
 			},
@@ -987,19 +1726,49 @@
 				"when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
 			},
 			{
+				"key": "alt+up",
+				"command": "showPrevParameterHint",
+				"when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
+			},
+			{
 				"key": "up",
 				"command": "showPrevParameterHint",
 				"when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
 			},
 			{
+				"key": "shift+tab",
+				"command": "acceptAlternativeSelectedSuggestion",
+				"when": "suggestWidgetHasFocusedSuggestion && suggestWidgetVisible && textInputFocus"
+			},
+			{
 				"key": "shift+enter",
 				"command": "acceptAlternativeSelectedSuggestion",
-				"when": "suggestWidgetVisible && textInputFocus && textInputFocus"
+				"when": "suggestWidgetHasFocusedSuggestion && suggestWidgetVisible && textInputFocus"
+			},
+			{
+				"key": "tab",
+				"command": "acceptSelectedSuggestion",
+				"when": "suggestWidgetHasFocusedSuggestion && suggestWidgetVisible && textInputFocus"
 			},
 			{
 				"key": "enter",
 				"command": "acceptSelectedSuggestion",
-				"when": "acceptSuggestionOnEnter && suggestWidgetVisible && suggestionMakesTextEdit && textInputFocus"
+				"when": "acceptSuggestionOnEnter && suggestWidgetHasFocusedSuggestion && suggestWidgetVisible && suggestionMakesTextEdit && textInputFocus"
+			},
+			{
+				"key": "cmd+i",
+				"command": "focusSuggestion",
+				"when": "suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "ctrl+space",
+				"command": "focusSuggestion",
+				"when": "suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "shift+escape",
+				"command": "hideSuggestWidget",
+				"when": "suggestWidgetVisible && textInputFocus"
 			},
 			{
 				"key": "escape",
@@ -1009,7 +1778,7 @@
 			{
 				"key": "tab",
 				"command": "insertBestCompletion",
-				"when": "atEndOfWord && !hasOtherSuggestions && !inSnippetMode && !suggestWidgetVisible && config.editor.tabCompletion == 'on'"
+				"when": "atEndOfWord && textInputFocus && !hasOtherSuggestions && !inSnippetMode && !suggestWidgetVisible && config.editor.tabCompletion == 'on'"
 			},
 			{
 				"key": "tab",
@@ -1024,47 +1793,107 @@
 			{
 				"key": "cmd+pagedown",
 				"command": "selectNextPageSuggestion",
-				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus"
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "pagedown",
+				"command": "selectNextPageSuggestion",
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
 			},
 			{
 				"key": "ctrl+n",
 				"command": "selectNextSuggestion",
-				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus"
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
 			},
 			{
 				"key": "cmd+down",
 				"command": "selectNextSuggestion",
-				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus"
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "down",
+				"command": "selectNextSuggestion",
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
 			},
 			{
 				"key": "cmd+pageup",
 				"command": "selectPrevPageSuggestion",
-				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus"
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "pageup",
+				"command": "selectPrevPageSuggestion",
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
 			},
 			{
 				"key": "ctrl+p",
 				"command": "selectPrevSuggestion",
-				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus"
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
 			},
 			{
 				"key": "cmd+up",
 				"command": "selectPrevSuggestion",
-				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus"
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "up",
+				"command": "selectPrevSuggestion",
+				"when": "suggestWidgetMultipleSuggestions && suggestWidgetVisible && textInputFocus || suggestWidgetVisible && textInputFocus && !suggestWidgetHasFocusedSuggestion"
+			},
+			{
+				"key": "cmd+i",
+				"command": "toggleSuggestionDetails",
+				"when": "suggestWidgetHasFocusedSuggestion && suggestWidgetVisible && textInputFocus"
 			},
 			{
 				"key": "ctrl+space",
 				"command": "toggleSuggestionDetails",
+				"when": "suggestWidgetHasFocusedSuggestion && suggestWidgetVisible && textInputFocus"
+			},
+			{
+				"key": "ctrl+alt+space",
+				"command": "toggleSuggestionFocus",
 				"when": "suggestWidgetVisible && textInputFocus"
 			},
 			{
 				"key": "enter",
 				"command": "acceptRenameInput",
+				"when": "editorFocus && renameInputVisible && !isComposing"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "acceptRenameInputWithPreview",
+				"when": "config.editor.rename.enablePreview && editorFocus && renameInputVisible && !isComposing"
+			},
+			{
+				"key": "shift+escape",
+				"command": "cancelLinkedEditingInput",
+				"when": "LinkedEditingInputVisible && editorTextFocus"
+			},
+			{
+				"key": "escape",
+				"command": "cancelLinkedEditingInput",
+				"when": "LinkedEditingInputVisible && editorTextFocus"
+			},
+			{
+				"key": "shift+escape",
+				"command": "cancelRenameInput",
 				"when": "editorFocus && renameInputVisible"
 			},
 			{
 				"key": "escape",
 				"command": "cancelRenameInput",
 				"when": "editorFocus && renameInputVisible"
+			},
+			{
+				"key": "down",
+				"command": "focusNextRenameSuggestion",
+				"when": "renameInputVisible"
+			},
+			{
+				"key": "up",
+				"command": "focusPreviousRenameSuggestion",
+				"when": "renameInputVisible"
 			},
 			{
 				"key": "shift+cmd+l",
@@ -1074,15 +1903,20 @@
 			{
 				"key": "shift+cmd+;",
 				"command": "breadcrumbs.focus",
-				"when": "breadcrumbsPossible"
+				"when": "breadcrumbsPossible && breadcrumbsVisible"
 			},
 			{
 				"key": "shift+cmd+.",
 				"command": "breadcrumbs.focusAndSelect",
-				"when": "breadcrumbsPossible"
+				"when": "breadcrumbsPossible && breadcrumbsVisible"
 			},
 			{
 				"key": "alt+right",
+				"command": "breadcrumbs.focusNext",
+				"when": "breadcrumbsActive && breadcrumbsVisible"
+			},
+			{
+				"key": "right",
 				"command": "breadcrumbs.focusNext",
 				"when": "breadcrumbsActive && breadcrumbsVisible"
 			},
@@ -1092,14 +1926,29 @@
 				"when": "breadcrumbsActive && breadcrumbsVisible"
 			},
 			{
+				"key": "left",
+				"command": "breadcrumbs.focusPrevious",
+				"when": "breadcrumbsActive && breadcrumbsVisible"
+			},
+			{
 				"key": "cmd+enter",
+				"command": "breadcrumbs.revealFocused",
+				"when": "breadcrumbsActive && breadcrumbsVisible"
+			},
+			{
+				"key": "space",
 				"command": "breadcrumbs.revealFocused",
 				"when": "breadcrumbsActive && breadcrumbsVisible"
 			},
 			{
 				"key": "cmd+enter",
 				"command": "breadcrumbs.revealFocusedFromTreeAside",
-				"when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus"
+				"when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "down",
+				"command": "breadcrumbs.selectFocused",
+				"when": "breadcrumbsActive && breadcrumbsVisible"
 			},
 			{
 				"key": "enter",
@@ -1113,8 +1962,23 @@
 			},
 			{
 				"key": "escape",
-				"command": "closeAccessibilityHelp",
-				"when": "accessibilityHelpWidgetVisible && editorFocus"
+				"command": "closeReplaceInFilesWidget",
+				"when": "replaceInputBoxFocus && searchViewletVisible"
+			},
+			{
+				"key": "escape",
+				"command": "commentsClearFilterText",
+				"when": "commentsFilterFocus"
+			},
+			{
+				"key": "cmd+f",
+				"command": "commentsFocusFilter",
+				"when": "focusedView == 'workbench.panel.comments'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "commentsFocusViewFromFilter",
+				"when": "commentsFilterFocus"
 			},
 			{
 				"key": "alt+cmd+c",
@@ -1122,9 +1986,24 @@
 				"when": "!editorFocus"
 			},
 			{
+				"key": "cmd+k alt+cmd+c",
+				"command": "copyFilePath",
+				"when": "editorFocus"
+			},
+			{
 				"key": "shift+alt+cmd+c",
 				"command": "copyRelativeFilePath",
 				"when": "!editorFocus"
+			},
+			{
+				"key": "cmd+k shift+alt+cmd+c",
+				"command": "copyRelativeFilePath",
+				"when": "editorFocus"
+			},
+			{
+				"key": "alt+enter",
+				"command": "debug.openBreakpointToSide",
+				"when": "breakpointsFocused"
 			},
 			{
 				"key": "cmd+enter",
@@ -1132,9 +2011,19 @@
 				"when": "breakpointsFocused"
 			},
 			{
+				"key": "cmd+f5",
+				"command": "debug.openView",
+				"when": "!debuggersAvailable"
+			},
+			{
+				"key": "f5",
+				"command": "debug.openView",
+				"when": "!debuggersAvailable"
+			},
+			{
 				"key": "cmd+backspace",
 				"command": "debug.removeBreakpoint",
-				"when": "breakpointsFocused && !breakpointSelected"
+				"when": "breakpointsFocused && !breakpointInputFocused"
 			},
 			{
 				"key": "cmd+backspace",
@@ -1142,39 +2031,278 @@
 				"when": "watchExpressionsFocused && !expressionSelected"
 			},
 			{
+				"key": "alt+-",
+				"command": "decreaseSearchEditorContextLines",
+				"when": "inSearchEditor"
+			},
+			{
+				"key": "alt+f1",
+				"command": "editor.action.accessibilityHelp",
+				"when": "!accessibilityHelpIsShown"
+			},
+			{
+				"key": "alt+k",
+				"command": "editor.action.accessibilityHelpConfigureKeybindings",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
+				"key": "alt+h",
+				"command": "editor.action.accessibilityHelpOpenHelpLink",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
+				"key": "alt+f2",
+				"command": "editor.action.accessibleView"
+			},
+			{
+				"key": "ctrl+/",
+				"command": "editor.action.accessibleViewAcceptInlineCompletion",
+				"when": "accessibleViewIsShown && accessibleViewCurrentProviderId == 'inlineCompletions'"
+			},
+			{
+				"key": "alt+f6",
+				"command": "editor.action.accessibleViewDisableHint",
+				"when": "accessibilityHelpIsShown && accessibleViewVerbosityEnabled || accessibleViewIsShown && accessibleViewVerbosityEnabled"
+			},
+			{
+				"key": "alt+]",
+				"command": "editor.action.accessibleViewNext",
+				"when": "accessibleViewIsShown && accessibleViewSupportsNavigation"
+			},
+			{
+				"key": "alt+cmd+pagedown",
+				"command": "editor.action.accessibleViewNextCodeBlock",
+				"when": "accessibleViewContainsCodeBlocks && accessibleViewCurrentProviderId == 'panelChat'"
+			},
+			{
+				"key": "alt+[",
+				"command": "editor.action.accessibleViewPrevious",
+				"when": "accessibleViewIsShown && accessibleViewSupportsNavigation"
+			},
+			{
+				"key": "alt+cmd+pageup",
+				"command": "editor.action.accessibleViewPreviousCodeBlock",
+				"when": "accessibleViewContainsCodeBlocks && accessibleViewCurrentProviderId == 'panelChat'"
+			},
+			{
+				"key": "cmd+k cmd+k",
+				"command": "editor.action.defineKeybinding",
+				"when": "resource == 'vscode-userdata:/Users/runner/work/vs-code-default-keybindings/vs-code-default-keybindings/scripts/get_default_keybindings/empty2/User/keybindings.json'"
+			},
+			{
+				"key": "tab",
+				"command": "editor.action.inlineSuggest.commit",
+				"when": "inlineSuggestionHasIndentationLessThanTabSize && inlineSuggestionVisible && !editorHoverFocused && !editorTabMovesFocus && !suggestWidgetVisible"
+			},
+			{
+				"key": "shift+f9",
+				"command": "editor.debug.action.toggleInlineBreakpoint",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "shift+alt+d",
+				"command": "editor.detectLanguage",
+				"when": "editorTextFocus && !notebookEditable"
+			},
+			{
 				"key": "shift+enter",
 				"command": "editor.refocusCallHierarchy",
 				"when": "callHierarchyVisible"
 			},
 			{
+				"key": "shift+enter",
+				"command": "editor.refocusTypeHierarchy",
+				"when": "typeHierarchyVisible"
+			},
+			{
 				"key": "shift+alt+h",
-				"command": "editor.toggleCallHierarchy",
-				"when": "callHierarchyVisible"
+				"command": "editor.showCallHierarchy",
+				"when": "editorHasCallHierarchyProvider && editorTextFocus && !inReferenceSearchEditor"
+			},
+			{
+				"key": "shift+alt+h",
+				"command": "editor.showIncomingCalls",
+				"when": "callHierarchyVisible && callHierarchyDirection == 'outgoingCalls'"
+			},
+			{
+				"key": "shift+alt+h",
+				"command": "editor.showOutgoingCalls",
+				"when": "callHierarchyVisible && callHierarchyDirection == 'incomingCalls'"
+			},
+			{
+				"key": "shift+alt+h",
+				"command": "editor.showSubtypes",
+				"when": "typeHierarchyVisible && typeHierarchyDirection == 'supertypes'"
+			},
+			{
+				"key": "shift+alt+h",
+				"command": "editor.showSupertypes",
+				"when": "typeHierarchyVisible && typeHierarchyDirection == 'subtypes'"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "explorer.openToSide",
+				"when": "explorerViewletFocus && foldersViewVisible && !inputFocus"
 			},
 			{
 				"key": "shift+alt+f",
 				"command": "filesExplorer.findInFolder",
-				"when": "explorerResourceIsFolder && explorerViewletVisible && filesExplorerFocus && !inputFocus"
+				"when": "explorerResourceIsFolder && filesExplorerFocus && foldersViewVisible && !inputFocus"
+			},
+			{
+				"key": "alt+down",
+				"command": "history.showNext",
+				"when": "historyNavigationForwardsEnabled && historyNavigationWidgetFocus && !isComposing && !suggestWidgetVisible"
 			},
 			{
 				"key": "down",
 				"command": "history.showNext",
-				"when": "historyNavigationEnabled && historyNavigationWidget"
+				"when": "historyNavigationForwardsEnabled && historyNavigationWidgetFocus && !isComposing && !suggestWidgetVisible"
+			},
+			{
+				"key": "alt+up",
+				"command": "history.showPrevious",
+				"when": "historyNavigationBackwardsEnabled && historyNavigationWidgetFocus && !isComposing && !suggestWidgetVisible"
 			},
 			{
 				"key": "up",
 				"command": "history.showPrevious",
-				"when": "historyNavigationEnabled && historyNavigationWidget"
+				"when": "historyNavigationBackwardsEnabled && historyNavigationWidgetFocus && !isComposing && !suggestWidgetVisible"
+			},
+			{
+				"key": "down",
+				"command": "iconSelectBox.focusDown",
+				"when": "iconSelectBoxFocus"
+			},
+			{
+				"key": "right",
+				"command": "iconSelectBox.focusNext",
+				"when": "iconSelectBoxFocus && iconSelectBoxInputEmpty || iconSelectBoxFocus && !iconSelectBoxInputFocus"
+			},
+			{
+				"key": "left",
+				"command": "iconSelectBox.focusPrevious",
+				"when": "iconSelectBoxFocus && iconSelectBoxInputEmpty || iconSelectBoxFocus && !iconSelectBoxInputFocus"
+			},
+			{
+				"key": "up",
+				"command": "iconSelectBox.focusUp",
+				"when": "iconSelectBoxFocus"
+			},
+			{
+				"key": "enter",
+				"command": "iconSelectBox.selectFocused",
+				"when": "iconSelectBoxFocus"
+			},
+			{
+				"key": "alt+=",
+				"command": "increaseSearchEditorContextLines",
+				"when": "inSearchEditor"
+			},
+			{
+				"key": "escape",
+				"command": "inlineChat.close",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "escape",
+				"command": "inlineChat.discardHunkChange",
+				"when": "inlineChatHasProvider && inlineChatVisible && inlineChatResponseType == 'messagesAndEdits'"
+			},
+			{
+				"key": "cmd+i",
+				"command": "inlineChat.holdForSpeech",
+				"when": "hasSpeechProvider && inlineChatHasProvider && inlineChatVisible && textInputFocus"
+			},
+			{
+				"key": "f7",
+				"command": "inlineChat.moveToNextHunk",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "shift+f7",
+				"command": "inlineChat.moveToPreviousHunk",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "cmd+r",
+				"command": "inlineChat.regenerate",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "cmd+k i",
+				"command": "inlineChat.start",
+				"when": "editorFocus && inlineChatHasProvider && !editorReadonly"
+			},
+			{
+				"key": "cmd+i",
+				"command": "inlineChat.start",
+				"when": "editorFocus && inlineChatHasProvider && !editorReadonly"
+			},
+			{
+				"key": "cmd+z",
+				"command": "inlineChat.unstash",
+				"when": "inlineChatHasStashedSession && !editorReadonly"
+			},
+			{
+				"key": "cmd+down",
+				"command": "inlineChat.viewInChat",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "down",
+				"command": "interactive.history.next",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.interactive' && interactiveInputCursorAtBoundary != 'none' && interactiveInputCursorAtBoundary != 'top'"
+			},
+			{
+				"key": "down",
+				"command": "interactive.history.next",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.repl' && interactiveInputCursorAtBoundary != 'none' && interactiveInputCursorAtBoundary != 'top'"
+			},
+			{
+				"key": "up",
+				"command": "interactive.history.previous",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.interactive' && interactiveInputCursorAtBoundary != 'bottom' && interactiveInputCursorAtBoundary != 'none'"
+			},
+			{
+				"key": "up",
+				"command": "interactive.history.previous",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.repl' && interactiveInputCursorAtBoundary != 'bottom' && interactiveInputCursorAtBoundary != 'none'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "interactive.scrollToBottom",
+				"when": "activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "cmd+up",
+				"command": "interactive.scrollToTop",
+				"when": "activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "enter",
+				"command": "keybindings.editor.acceptWhenExpression",
+				"when": "inKeybindings && whenFocus && !suggestWidgetVisible"
+			},
+			{
+				"key": "cmd+k cmd+a",
+				"command": "keybindings.editor.addKeybinding",
+				"when": "inKeybindings && keybindingFocus"
+			},
+			{
+				"key": "escape",
+				"command": "keybindings.editor.clearSearchResults",
+				"when": "inKeybindings && inKeybindingsSearch"
 			},
 			{
 				"key": "cmd+c",
 				"command": "keybindings.editor.copyKeybindingEntry",
-				"when": "inKeybindings && keybindingFocus"
+				"when": "inKeybindings && keybindingFocus && !whenFocus"
 			},
 			{
-				"key": "cmd+k cmd+k",
+				"key": "enter",
 				"command": "keybindings.editor.defineKeybinding",
-				"when": "inKeybindings && keybindingFocus"
+				"when": "inKeybindings && keybindingFocus && !whenFocus"
 			},
 			{
 				"key": "cmd+k cmd+e",
@@ -1182,7 +2310,7 @@
 				"when": "inKeybindings && keybindingFocus"
 			},
 			{
-				"key": "down",
+				"key": "cmd+down",
 				"command": "keybindings.editor.focusKeybindings",
 				"when": "inKeybindings && inKeybindingsSearch"
 			},
@@ -1192,9 +2320,14 @@
 				"when": "inKeybindings && inKeybindingsSearch"
 			},
 			{
-				"key": "cmd+k cmd+backspace",
+				"key": "escape",
+				"command": "keybindings.editor.rejectWhenExpression",
+				"when": "inKeybindings && whenFocus && !suggestWidgetVisible"
+			},
+			{
+				"key": "cmd+backspace",
 				"command": "keybindings.editor.removeKeybinding",
-				"when": "inKeybindings && keybindingFocus"
+				"when": "inKeybindings && keybindingFocus && !inputFocus"
 			},
 			{
 				"key": "cmd+f",
@@ -1207,83 +2340,423 @@
 				"when": "inKeybindings"
 			},
 			{
+				"key": "escape",
+				"command": "list.clear",
+				"when": "listFocus && listHasSelectionOrFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "escape",
+				"command": "list.closeFind",
+				"when": "listFocus && treeFindOpen"
+			},
+			{
 				"key": "cmd+up",
 				"command": "list.collapse",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && treeElementCanCollapse && !inputFocus && !treestickyScrollFocused || listFocus && treeElementHasParent && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "left",
 				"command": "list.collapse",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && treeElementCanCollapse && !inputFocus && !treestickyScrollFocused || listFocus && treeElementHasParent && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "shift+cmd+up",
 				"command": "list.collapseAll",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "cmd+left",
 				"command": "list.collapseAll",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "right",
+				"command": "list.expand",
+				"when": "listFocus && treeElementCanExpand && !inputFocus && !treestickyScrollFocused || listFocus && treeElementHasChild && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "shift+down",
 				"command": "list.expandSelectionDown",
-				"when": "listFocus && listSupportsMultiselect && !inputFocus"
+				"when": "listFocus && listSupportsMultiselect && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "shift+up",
+				"command": "list.expandSelectionUp",
+				"when": "listFocus && listSupportsMultiselect && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "f3",
+				"command": "list.find",
+				"when": "listFocus && listSupportsFind"
+			},
+			{
+				"key": "alt+cmd+f",
+				"command": "list.find",
+				"when": "listFocus && listSupportsFind"
+			},
+			{
+				"key": "ctrl+alt+n",
+				"command": "list.focusAnyDown",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "alt+down",
+				"command": "list.focusAnyDown",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "alt+home",
+				"command": "list.focusAnyFirst",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "alt+end",
+				"command": "list.focusAnyLast",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "ctrl+alt+p",
+				"command": "list.focusAnyUp",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "alt+up",
+				"command": "list.focusAnyUp",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "ctrl+n",
 				"command": "list.focusDown",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "down",
 				"command": "list.focusDown",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "home",
+				"command": "list.focusFirst",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "end",
 				"command": "list.focusLast",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "pagedown",
+				"command": "list.focusPageDown",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "pageup",
 				"command": "list.focusPageUp",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "ctrl+p",
 				"command": "list.focusUp",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "up",
+				"command": "list.focusUp",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "cmd+down",
 				"command": "list.scrollDown",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused && listScrollAtBoundary != 'both' && listScrollAtBoundary != 'bottom'"
 			},
 			{
 				"key": "cmd+up",
 				"command": "list.scrollUp",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused && listScrollAtBoundary != 'both' && listScrollAtBoundary != 'top'"
 			},
 			{
 				"key": "cmd+down",
 				"command": "list.select",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "enter",
+				"command": "list.select",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "cmd+a",
 				"command": "list.selectAll",
-				"when": "listFocus && listSupportsMultiselect && !inputFocus"
+				"when": "listFocus && listSupportsMultiselect && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "cmd+k cmd+i",
+				"command": "list.showHover",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "space",
+				"command": "list.toggleExpand",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "shift+cmd+enter",
 				"command": "list.toggleSelection",
-				"when": "listFocus && !inputFocus"
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "y",
+				"command": "notebook.cell.changeToCode",
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused && activeEditor == 'workbench.editor.notebook' && notebookCellType == 'markup'"
+			},
+			{
+				"key": "m",
+				"command": "notebook.cell.changeToMarkdown",
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused && activeEditor == 'workbench.editor.notebook' && notebookCellType == 'code'"
+			},
+			{
+				"key": "enter",
+				"command": "notebook.cell.chat.accept",
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "notebook.cell.chat.acceptChanges",
+				"when": "notebookEditorFocused && !inputFocus && !notebookCellEditorFocused && notebookChatOuterFocusPosition == 'below'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "notebook.cell.chat.focus",
+				"when": "notebookEditorFocused && !inputFocus && notebookChatOuterFocusPosition == 'above'"
+			},
+			{
+				"key": "cmd+up",
+				"command": "notebook.cell.chat.focus",
+				"when": "notebookEditorFocused && !inputFocus && notebookChatOuterFocusPosition == 'below'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "notebook.cell.chat.focusNextCell",
+				"when": "inlineChatFocused && notebookCellChatFocused"
+			},
+			{
+				"key": "cmd+up",
+				"command": "notebook.cell.chat.focusPreviousCell",
+				"when": "inlineChatFocused && notebookCellChatFocused"
+			},
+			{
+				"key": "cmd+k i",
+				"command": "notebook.cell.chat.start",
+				"when": "config.notebook.experimental.cellChat && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus || config.notebook.experimental.generate && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+i",
+				"command": "notebook.cell.chat.start",
+				"when": "config.notebook.experimental.cellChat && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus || config.notebook.experimental.generate && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "alt+delete",
+				"command": "notebook.cell.clearOutputs",
+				"when": "notebookCellEditable && notebookCellHasOutputs && notebookEditable && notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+k cmd+c",
+				"command": "notebook.cell.collapseCellInput",
+				"when": "notebookCellListFocused && !inputFocus && !notebookCellInputIsCollapsed"
+			},
+			{
+				"key": "cmd+k t",
+				"command": "notebook.cell.collapseCellOutput",
+				"when": "notebookCellHasOutputs && notebookCellListFocused && !inputFocus && !notebookCellOutputIsCollapsed"
+			},
+			{
+				"key": "shift+alt+down",
+				"command": "notebook.cell.copyDown",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "shift+alt+up",
+				"command": "notebook.cell.copyUp",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+backspace",
+				"command": "notebook.cell.delete",
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputInputFocused"
+			},
+			{
+				"key": "shift+alt+d",
+				"command": "notebook.cell.detectLanguage",
+				"when": "notebookCellEditable && notebookEditable"
+			},
+			{
+				"key": "enter",
+				"command": "notebook.cell.edit",
+				"when": "notebookCellListFocused && notebookEditable && !editorHoverFocused && !inputFocus && !notebookOutputInputFocused"
+			},
+			{
+				"key": "cmd+k cmd+c",
+				"command": "notebook.cell.expandCellInput",
+				"when": "notebookCellInputIsCollapsed && notebookCellListFocused"
+			},
+			{
+				"key": "cmd+k t",
+				"command": "notebook.cell.expandCellOutput",
+				"when": "notebookCellListFocused && notebookCellOutputIsCollapsed"
+			},
+			{
+				"key": "ctrl+cmd+down",
+				"command": "notebook.cell.focusInOutput",
+				"when": "notebookCellHasOutputs && notebookEditorFocused"
+			},
+			{
+				"key": "ctrl+cmd+up",
+				"command": "notebook.cell.focusOutOutput",
+				"when": "notebookEditorFocused && notebookOutputFocused"
+			},
+			{
+				"key": "shift+cmd+enter",
+				"command": "notebook.cell.insertCodeCellAbove",
+				"when": "notebookCellListFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "notebook.cell.insertCodeCellBelow",
+				"when": "notebookCellListFocused && !inputFocus && notebookChatOuterFocusPosition == ''"
+			},
+			{
+				"key": "ctrl+shift+alt+j",
+				"command": "notebook.cell.joinAbove",
+				"when": "notebookEditorFocused"
+			},
+			{
+				"key": "ctrl+alt+j",
+				"command": "notebook.cell.joinBelow",
+				"when": "notebookEditorFocused"
+			},
+			{
+				"key": "alt+down",
+				"command": "notebook.cell.moveDown",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "alt+up",
+				"command": "notebook.cell.moveUp",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+.",
+				"command": "notebook.cell.openFailureActions",
+				"when": "notebookCellFocused && notebookCellHasErrorDiagnostics && !notebookCellEditorFocused"
+			},
+			{
+				"key": "cmd+k shift+cmd+\\",
+				"command": "notebook.cell.split",
+				"when": "editorTextFocus && notebookCellEditable && notebookEditable && notebookEditorFocused"
+			},
+			{
+				"key": "cmd+k y",
+				"command": "notebook.cell.toggleOutputScrolling",
+				"when": "notebookCellHasOutputs && notebookCellListFocused && !inputFocus"
+			},
+			{
+				"key": "ctrl+l",
+				"command": "notebook.centerActiveCell",
+				"when": "notebookEditorFocused"
+			},
+			{
+				"key": "alt+f3",
+				"command": "notebook.diff.action.next",
+				"when": "activeEditor == 'workbench.editor.notebookTextDiffEditor'"
+			},
+			{
+				"key": "shift+alt+f3",
+				"command": "notebook.diff.action.previous",
+				"when": "activeEditor == 'workbench.editor.notebookTextDiffEditor'"
+			},
+			{
+				"key": "cmd+f",
+				"command": "notebook.find",
+				"when": "notebookEditorFocused && !editorFocus && activeEditor == 'workbench.editor.interactive' || notebookEditorFocused && !editorFocus && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "cmd+end",
+				"command": "notebook.focusBottom",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+down",
+				"command": "notebook.focusBottom",
+				"when": "notebookEditorFocused && !inputFocus && notebookChatOuterFocusPosition == ''"
+			},
+			{
+				"key": "down",
+				"command": "notebook.focusNextEditor",
+				"when": "config.notebook.navigation.allowNavigateToSurroundingCells && notebookCursorNavigationMode && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && !notebookCellMarkdownEditMode && notebookCellType == 'markup'"
+			},
+			{
+				"key": "ctrl+cmd+down",
+				"command": "notebook.focusNextEditor",
+				"when": "notebookEditorFocused && notebookOutputFocused"
+			},
+			{
+				"key": "up",
+				"command": "notebook.focusPreviousEditor",
+				"when": "config.notebook.navigation.allowNavigateToSurroundingCells && notebookCursorNavigationMode && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && !notebookCellMarkdownEditMode && notebookCellType == 'markup'"
+			},
+			{
+				"key": "cmd+home",
+				"command": "notebook.focusTop",
+				"when": "notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "cmd+up",
+				"command": "notebook.focusTop",
+				"when": "notebookEditorFocused && !inputFocus && notebookChatOuterFocusPosition == ''"
+			},
+			{
+				"key": "left",
+				"command": "notebook.fold",
+				"when": "notebookEditorFocused && !inputFocus && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "alt+cmd+[",
+				"command": "notebook.fold",
+				"when": "notebookEditorFocused && !inputFocus && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "shift+alt+f",
+				"command": "notebook.format",
+				"when": "notebookEditable && !editorTextFocus && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "escape",
+				"command": "notebook.hideFind",
+				"when": "notebookEditorFocused && notebookFindWidgetFocused"
+			},
+			{
+				"key": "right",
+				"command": "notebook.unfold",
+				"when": "notebookEditorFocused && !inputFocus && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "alt+cmd+]",
+				"command": "notebook.unfold",
+				"when": "notebookEditorFocused && !inputFocus && activeEditor == 'workbench.editor.notebook'"
+			},
+			{
+				"key": "shift+cmd+a",
+				"command": "notification.acceptPrimaryAction",
+				"when": "notificationFocus || notificationToastsVisible"
 			},
 			{
 				"key": "cmd+backspace",
 				"command": "notification.clear",
+				"when": "notificationFocus"
+			},
+			{
+				"key": "left",
+				"command": "notification.collapse",
 				"when": "notificationFocus"
 			},
 			{
@@ -1292,13 +2765,28 @@
 				"when": "notificationFocus"
 			},
 			{
+				"key": "enter",
+				"command": "notification.toggle",
+				"when": "notificationFocus"
+			},
+			{
 				"key": "space",
 				"command": "notification.toggle",
 				"when": "notificationFocus"
 			},
 			{
+				"key": "home",
+				"command": "notifications.focusFirstToast",
+				"when": "notificationFocus && notificationToastsVisible"
+			},
+			{
 				"key": "pageup",
 				"command": "notifications.focusFirstToast",
+				"when": "notificationFocus && notificationToastsVisible"
+			},
+			{
+				"key": "end",
+				"command": "notifications.focusLastToast",
 				"when": "notificationFocus && notificationToastsVisible"
 			},
 			{
@@ -1307,19 +2795,33 @@
 				"when": "notificationFocus && notificationToastsVisible"
 			},
 			{
+				"key": "down",
+				"command": "notifications.focusNextToast",
+				"when": "notificationFocus && notificationToastsVisible"
+			},
+			{
 				"key": "up",
 				"command": "notifications.focusPreviousToast",
 				"when": "notificationFocus && notificationToastsVisible"
 			},
 			{
+				"key": "cmd+k shift+cmd+n",
+				"command": "notifications.showList"
+			},
+			{
+				"key": "escape",
+				"command": "problems.action.clearFilterText",
+				"when": "problemsFilterFocus"
+			},
+			{
 				"key": "cmd+c",
 				"command": "problems.action.copy",
-				"when": "problemFocus"
+				"when": "problemsVisibility && !relatedInformationFocus && focusedView == 'workbench.panel.markers.view'"
 			},
 			{
 				"key": "cmd+f",
 				"command": "problems.action.focusFilter",
-				"when": "problemsViewFocus"
+				"when": "focusedView == 'workbench.panel.markers.view'"
 			},
 			{
 				"key": "cmd+down",
@@ -1327,19 +2829,228 @@
 				"when": "problemsFilterFocus"
 			},
 			{
+				"key": "cmd+down",
+				"command": "problems.action.open",
+				"when": "problemFocus"
+			},
+			{
+				"key": "enter",
+				"command": "problems.action.open",
+				"when": "problemFocus"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "problems.action.openToSide",
+				"when": "problemFocus"
+			},
+			{
 				"key": "cmd+.",
 				"command": "problems.action.showQuickFixes",
 				"when": "problemFocus"
 			},
 			{
-				"key": "shift+cmd+r",
-				"command": "rerunSearchEditorSearch",
-				"when": "inSearchEditor"
+				"key": "ctrl+alt+cmd+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+cmd+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+down",
+				"command": "quickInput.next",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "down",
+				"command": "quickInput.next",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+cmd+down",
+				"command": "quickInput.nextSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+down",
+				"command": "quickInput.nextSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+cmd+down",
+				"command": "quickInput.nextSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "cmd+down",
+				"command": "quickInput.nextSeparatorWithQuickAccessFallback",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+cmd+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+cmd+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "cmd+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+cmd+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+cmd+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "cmd+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+up",
+				"command": "quickInput.previous",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "up",
+				"command": "quickInput.previous",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+cmd+up",
+				"command": "quickInput.previousSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+up",
+				"command": "quickInput.previousSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+cmd+up",
+				"command": "quickInput.previousSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "cmd+up",
+				"command": "quickInput.previousSeparatorWithQuickAccessFallback",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "space",
+				"command": "refactorPreview.toggleCheckedState",
+				"when": "listFocus && refactorPreview.enabled && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "alt+cmd+r",
 				"command": "revealFileInOS",
 				"when": "!editorFocus"
+			},
+			{
+				"key": "cmd+down",
+				"command": "revealReference",
+				"when": "listFocus && referenceSearchVisible && !inputFocus && !treeElementCanCollapse && !treeElementCanExpand && !treestickyScrollFocused"
+			},
+			{
+				"key": "enter",
+				"command": "revealReference",
+				"when": "listFocus && referenceSearchVisible && !inputFocus && !treeElementCanCollapse && !treeElementCanExpand && !treestickyScrollFocused"
+			},
+			{
+				"key": "alt+cmd+s",
+				"command": "saveAll"
 			},
 			{
 				"key": "cmd+enter",
@@ -1348,8 +3059,33 @@
 			},
 			{
 				"key": "escape",
+				"command": "scm.clearInput",
+				"when": "scmRepository && !suggestWidgetVisible"
+			},
+			{
+				"key": "alt+down",
+				"command": "scm.forceViewNextCommit",
+				"when": "scmRepository"
+			},
+			{
+				"key": "alt+up",
+				"command": "scm.forceViewPreviousCommit",
+				"when": "scmRepository"
+			},
+			{
+				"key": "down",
+				"command": "scm.viewNextCommit",
+				"when": "scmInputIsInLastPosition && scmRepository && !suggestWidgetVisible"
+			},
+			{
+				"key": "up",
+				"command": "scm.viewPreviousCommit",
+				"when": "scmInputIsInFirstPosition && scmRepository && !suggestWidgetVisible"
+			},
+			{
+				"key": "escape",
 				"command": "search.action.cancel",
-				"when": "listFocus && searchViewletVisible && !inputFocus"
+				"when": "listFocus && searchViewletVisible && !inputFocus && !treestickyScrollFocused && searchState != '0'"
 			},
 			{
 				"key": "cmd+c",
@@ -1362,6 +3098,11 @@
 				"when": "fileMatchOrFolderMatchWithResourceFocus"
 			},
 			{
+				"key": "f4",
+				"command": "search.action.focusNextSearchResult",
+				"when": "hasSearchResult || inSearchEditor"
+			},
+			{
 				"key": "shift+f4",
 				"command": "search.action.focusPreviousSearchResult",
 				"when": "hasSearchResult || inSearchEditor"
@@ -1369,12 +3110,27 @@
 			{
 				"key": "cmd+up",
 				"command": "search.action.focusSearchFromResults",
-				"when": "firstMatchFocus && searchViewletVisible"
+				"when": "accessibilityModeEnabled && searchViewletVisible || firstMatchFocus && searchViewletVisible"
 			},
 			{
 				"key": "cmd+enter",
 				"command": "search.action.openInEditor",
 				"when": "hasSearchResult && searchViewletFocus"
+			},
+			{
+				"key": "cmd+down",
+				"command": "search.action.openResult",
+				"when": "fileMatchOrMatchFocus && searchViewletVisible"
+			},
+			{
+				"key": "enter",
+				"command": "search.action.openResult",
+				"when": "fileMatchOrMatchFocus && searchViewletVisible"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "search.action.openResultToSide",
+				"when": "fileMatchOrMatchFocus && searchViewletVisible"
 			},
 			{
 				"key": "cmd+backspace",
@@ -1384,7 +3140,7 @@
 			{
 				"key": "shift+cmd+1",
 				"command": "search.action.replace",
-				"when": "matchFocus && replaceActive && searchViewletVisible"
+				"when": "isEditableItem && matchFocus && replaceActive && searchViewletVisible"
 			},
 			{
 				"key": "alt+cmd+enter",
@@ -1394,22 +3150,27 @@
 			{
 				"key": "shift+cmd+enter",
 				"command": "search.action.replaceAllInFile",
-				"when": "fileMatchFocus && replaceActive && searchViewletVisible"
+				"when": "fileMatchFocus && isEditableItem && replaceActive && searchViewletVisible"
 			},
 			{
 				"key": "shift+cmd+1",
 				"command": "search.action.replaceAllInFile",
-				"when": "fileMatchFocus && replaceActive && searchViewletVisible"
+				"when": "fileMatchFocus && isEditableItem && replaceActive && searchViewletVisible"
 			},
 			{
 				"key": "shift+cmd+enter",
 				"command": "search.action.replaceAllInFolder",
-				"when": "folderMatchFocus && replaceActive && searchViewletVisible"
+				"when": "folderMatchFocus && isEditableItem && replaceActive && searchViewletVisible"
 			},
 			{
 				"key": "shift+cmd+1",
 				"command": "search.action.replaceAllInFolder",
-				"when": "folderMatchFocus && replaceActive && searchViewletVisible"
+				"when": "folderMatchFocus && isEditableItem && replaceActive && searchViewletVisible"
+			},
+			{
+				"key": "shift+alt+f",
+				"command": "search.action.restrictSearchToFolder",
+				"when": "folderMatchWithResourceFocus && searchViewletVisible"
 			},
 			{
 				"key": "cmd+down",
@@ -1427,9 +3188,127 @@
 				"when": "inSearchEditor"
 			},
 			{
+				"key": "escape",
+				"command": "settings.action.focusLevelUp",
+				"when": "inSettingsEditor && !inSettingsJSONEditor && !inSettingsSearch"
+			},
+			{
+				"key": "enter",
+				"command": "settings.action.focusSettingControl",
+				"when": "inSettingsEditor && settingRowFocus"
+			},
+			{
+				"key": "down",
+				"command": "settings.action.focusSettingsFromSearch",
+				"when": "inSettingsSearch && !suggestWidgetVisible"
+			},
+			{
 				"key": "enter",
 				"command": "settings.action.focusSettingsList",
 				"when": "inSettingsEditor && settingsTocRowFocus"
+			},
+			{
+				"key": "left",
+				"command": "settings.action.focusTOC",
+				"when": "inSettingsEditor && settingRowFocus"
+			},
+			{
+				"key": "shift+f9",
+				"command": "settings.action.showContextMenu",
+				"when": "inSettingsEditor"
+			},
+			{
+				"key": "cmd+; cmd+x",
+				"command": "testing.cancelRun"
+			},
+			{
+				"key": "cmd+; shift+cmd+a",
+				"command": "testing.coverageAll"
+			},
+			{
+				"key": "cmd+; shift+cmd+c",
+				"command": "testing.coverageAtCursor",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "cmd+; shift+cmd+f",
+				"command": "testing.coverageCurrentFile",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "cmd+; shift+cmd+l",
+				"command": "testing.coverageLastRun"
+			},
+			{
+				"key": "cmd+; cmd+a",
+				"command": "testing.debugAll"
+			},
+			{
+				"key": "cmd+; cmd+c",
+				"command": "testing.debugAtCursor",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "cmd+; cmd+f",
+				"command": "testing.debugCurrentFile",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "cmd+; cmd+e",
+				"command": "testing.debugFailTests"
+			},
+			{
+				"key": "cmd+; cmd+l",
+				"command": "testing.debugLastRun"
+			},
+			{
+				"key": "cmd+; cmd+m",
+				"command": "testing.openOutputPeek"
+			},
+			{
+				"key": "cmd+; e",
+				"command": "testing.reRunFailTests"
+			},
+			{
+				"key": "cmd+; l",
+				"command": "testing.reRunLastRun"
+			},
+			{
+				"key": "cmd+; cmd+r",
+				"command": "testing.refreshTests",
+				"when": "testing.canRefresh"
+			},
+			{
+				"key": "cmd+; a",
+				"command": "testing.runAll"
+			},
+			{
+				"key": "cmd+; c",
+				"command": "testing.runAtCursor",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "cmd+; f",
+				"command": "testing.runCurrentFile",
+				"when": "editorTextFocus"
+			},
+			{
+				"key": "cmd+; cmd+o",
+				"command": "testing.showMostRecentOutput",
+				"when": "testing.hasAnyResults"
+			},
+			{
+				"key": "cmd+; shift+cmd+i",
+				"command": "testing.toggleInlineCoverage"
+			},
+			{
+				"key": "cmd+; cmd+i",
+				"command": "testing.toggleInlineTestOutput"
+			},
+			{
+				"key": "alt+h",
+				"command": "testing.toggleTestingPeekHistory",
+				"when": "testing.isPeekVisible"
 			},
 			{
 				"key": "alt+cmd+c",
@@ -1457,6 +3336,11 @@
 				"when": "inSearchEditor && searchInputBoxFocus"
 			},
 			{
+				"key": "alt+cmd+p",
+				"command": "toggleSearchPreserveCase",
+				"when": "searchViewletFocus"
+			},
+			{
 				"key": "alt+cmd+r",
 				"command": "toggleSearchRegex",
 				"when": "searchViewletFocus"
@@ -1465,6 +3349,83 @@
 				"key": "alt+cmd+w",
 				"command": "toggleSearchWholeWord",
 				"when": "searchViewletFocus"
+			},
+			{
+				"key": "ctrl+alt+cmd+n",
+				"command": "welcome.showNewFileEntries"
+			},
+			{
+				"key": "cmd+down",
+				"command": "widgetNavigation.focusNext",
+				"when": "inputFocus && navigableContainerFocused || navigableContainerFocused && treestickyScrollFocused || navigableContainerFocused && !listFocus || navigableContainerFocused && listScrollAtBoundary == 'both' || navigableContainerFocused && listScrollAtBoundary == 'bottom'"
+			},
+			{
+				"key": "cmd+up",
+				"command": "widgetNavigation.focusPrevious",
+				"when": "inputFocus && navigableContainerFocused || navigableContainerFocused && treestickyScrollFocused || navigableContainerFocused && !listFocus || navigableContainerFocused && listScrollAtBoundary == 'both' || navigableContainerFocused && listScrollAtBoundary == 'top'"
+			},
+			{
+				"key": "cmd+escape",
+				"command": "workbench.action.chat.cancel"
+			},
+			{
+				"key": "cmd+down",
+				"command": "workbench.action.chat.focusInput",
+				"when": "inChat && !inChatInput"
+			},
+			{
+				"key": "cmd+i",
+				"command": "workbench.action.chat.holdToVoiceChatInChatView",
+				"when": "chatIsEnabled && hasSpeechProvider && !chatSessionRequestInProgress && !editorFocus && !inChatInput && !inlineChatFocused && !notebookEditorFocused"
+			},
+			{
+				"key": "ctrl+l",
+				"command": "workbench.action.chat.newChat",
+				"when": "chatIsEnabled && inChat"
+			},
+			{
+				"key": "alt+cmd+pagedown",
+				"command": "workbench.action.chat.nextCodeBlock",
+				"when": "chatIsEnabled && inChat"
+			},
+			{
+				"key": "cmd+f9",
+				"command": "workbench.action.chat.nextFileTree",
+				"when": "chatIsEnabled && inChat"
+			},
+			{
+				"key": "ctrl+cmd+i",
+				"command": "workbench.action.chat.open"
+			},
+			{
+				"key": "alt+cmd+pageup",
+				"command": "workbench.action.chat.previousCodeBlock",
+				"when": "chatIsEnabled && inChat"
+			},
+			{
+				"key": "shift+cmd+f9",
+				"command": "workbench.action.chat.previousFileTree",
+				"when": "chatIsEnabled && inChat"
+			},
+			{
+				"key": "cmd+backspace",
+				"command": "workbench.action.chat.remove",
+				"when": "inChat && !inChatInput"
+			},
+			{
+				"key": "shift+cmd+enter",
+				"command": "workbench.action.chat.sendToNewChat",
+				"when": "chatInputHasText && inChatInput && !chatSessionRequestInProgress"
+			},
+			{
+				"key": "cmd+i",
+				"command": "workbench.action.chat.startVoiceChat",
+				"when": "chatIsEnabled && hasSpeechProvider && inChatInput && !chatSessionRequestInProgress && !editorFocus && !notebookEditorFocused && !scopedVoiceChatGettingReady && !speechToTextInProgress && !terminalChatActiveRequest || chatIsEnabled && hasSpeechProvider && inlineChatFocused && !chatSessionRequestInProgress && !editorFocus && !notebookEditorFocused && !scopedVoiceChatGettingReady && !speechToTextInProgress && !terminalChatActiveRequest"
+			},
+			{
+				"key": "cmd+i",
+				"command": "workbench.action.chat.stopListeningAndSubmit",
+				"when": "inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'view' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'view'"
 			},
 			{
 				"key": "cmd+w",
@@ -1484,7 +3445,8 @@
 			},
 			{
 				"key": "cmd+k f",
-				"command": "workbench.action.closeFolder"
+				"command": "workbench.action.closeFolder",
+				"when": "emptyWorkspaceSupport && workbenchState != 'empty'"
 			},
 			{
 				"key": "cmd+w",
@@ -1494,6 +3456,11 @@
 			{
 				"key": "alt+cmd+t",
 				"command": "workbench.action.closeOtherEditors"
+			},
+			{
+				"key": "shift+escape",
+				"command": "workbench.action.closeQuickOpen",
+				"when": "inQuickOpen"
 			},
 			{
 				"key": "escape",
@@ -1514,14 +3481,29 @@
 				"when": "!editorIsOpen && !multipleEditorGroups"
 			},
 			{
+				"key": "alt+f5",
+				"command": "workbench.action.compareEditor.nextChange",
+				"when": "textCompareEditorVisible"
+			},
+			{
+				"key": "cmd+k shift+o",
+				"command": "workbench.action.compareEditor.openSide",
+				"when": "inDiffEditor"
+			},
+			{
 				"key": "shift+alt+f5",
 				"command": "workbench.action.compareEditor.previousChange",
 				"when": "textCompareEditorVisible"
 			},
 			{
-				"key": "f5",
-				"command": "workbench.action.debug.continue",
-				"when": "inDebugMode"
+				"key": "cmd+k o",
+				"command": "workbench.action.copyEditorToNewWindow",
+				"when": "activeEditor"
+			},
+			{
+				"key": "shift+f5",
+				"command": "workbench.action.debug.disconnect",
+				"when": "focusedSessionIsAttach && inDebugMode"
 			},
 			{
 				"key": "shift+cmd+f5",
@@ -1530,12 +3512,23 @@
 			},
 			{
 				"key": "ctrl+f5",
-				"command": "workbench.action.debug.run"
+				"command": "workbench.action.debug.run",
+				"when": "debuggersAvailable && debugState != 'initializing'"
 			},
 			{
 				"key": "f5",
 				"command": "workbench.action.debug.start",
-				"when": "!inDebugMode"
+				"when": "debuggersAvailable && debugState == 'inactive'"
+			},
+			{
+				"key": "cmd+f11",
+				"command": "workbench.action.debug.stepIntoTarget",
+				"when": "inDebugMode && stepIntoTargetsSupported && debugState == 'stopped'"
+			},
+			{
+				"key": "shift+f11",
+				"command": "workbench.action.debug.stepOut",
+				"when": "debugState == 'stopped'"
 			},
 			{
 				"key": "f10",
@@ -1545,11 +3538,17 @@
 			{
 				"key": "shift+f5",
 				"command": "workbench.action.debug.stop",
-				"when": "inDebugMode"
+				"when": "inDebugMode && !focusedSessionIsAttach"
 			},
 			{
 				"key": "cmd+k m",
-				"command": "workbench.action.editor.changeLanguageMode"
+				"command": "workbench.action.editor.changeLanguageMode",
+				"when": "!notebookEditorFocused"
+			},
+			{
+				"key": "alt+cmd+v",
+				"command": "workbench.action.editorDictation.start",
+				"when": "hasSpeechProvider && !editorReadonly && !speechToTextInProgress"
 			},
 			{
 				"key": "cmd+k p",
@@ -1561,7 +3560,18 @@
 			},
 			{
 				"key": "cmd+o",
-				"command": "workbench.action.files.openFileFolder"
+				"command": "workbench.action.files.openFile",
+				"when": "false"
+			},
+			{
+				"key": "cmd+o",
+				"command": "workbench.action.files.openFileFolder",
+				"when": "isMacNative && openFolderWorkspaceSupport"
+			},
+			{
+				"key": "cmd+o",
+				"command": "workbench.action.files.openFolderViaWorkspace",
+				"when": "!openFolderWorkspaceSupport && workbenchState == 'workspace'"
 			},
 			{
 				"key": "cmd+o",
@@ -1577,10 +3587,6 @@
 				"command": "workbench.action.files.save"
 			},
 			{
-				"key": "alt+cmd+s",
-				"command": "workbench.action.files.saveAll"
-			},
-			{
 				"key": "shift+cmd+s",
 				"command": "workbench.action.files.saveAs"
 			},
@@ -1592,10 +3598,6 @@
 			{
 				"key": "cmd+k s",
 				"command": "workbench.action.files.saveWithoutFormatting"
-			},
-			{
-				"key": "cmd+k o",
-				"command": "workbench.action.files.showOpenedFileInNewWindow"
 			},
 			{
 				"key": "shift+cmd+f",
@@ -1630,6 +3632,14 @@
 				"command": "workbench.action.focusLeftGroup"
 			},
 			{
+				"key": "f6",
+				"command": "workbench.action.focusNextPart"
+			},
+			{
+				"key": "shift+f6",
+				"command": "workbench.action.focusPreviousPart"
+			},
+			{
 				"key": "cmd+k cmd+right",
 				"command": "workbench.action.focusRightGroup"
 			},
@@ -1654,8 +3664,13 @@
 				"command": "workbench.action.focusThirdEditorGroup"
 			},
 			{
+				"key": "ctrl+g",
+				"command": "workbench.action.gotoLine"
+			},
+			{
 				"key": "shift+cmd+o",
-				"command": "workbench.action.gotoSymbol"
+				"command": "workbench.action.gotoSymbol",
+				"when": "!accessibilityHelpIsShown && !accessibleViewIsShown"
 			},
 			{
 				"key": "down",
@@ -1663,9 +3678,24 @@
 				"when": "interactivePlaygroundFocus && !editorTextFocus"
 			},
 			{
+				"key": "up",
+				"command": "workbench.action.interactivePlayground.arrowUp",
+				"when": "interactivePlaygroundFocus && !editorTextFocus"
+			},
+			{
 				"key": "pagedown",
 				"command": "workbench.action.interactivePlayground.pageDown",
 				"when": "interactivePlaygroundFocus && !editorTextFocus"
+			},
+			{
+				"key": "pageup",
+				"command": "workbench.action.interactivePlayground.pageUp",
+				"when": "interactivePlaygroundFocus && !editorTextFocus"
+			},
+			{
+				"key": "cmd+k shift+cmd+\\",
+				"command": "workbench.action.joinEditorInGroup",
+				"when": "sideBySideEditorActive"
 			},
 			{
 				"key": "cmd+k enter",
@@ -1725,11 +3755,13 @@
 			},
 			{
 				"key": "ctrl+-",
-				"command": "workbench.action.navigateBack"
+				"command": "workbench.action.navigateBack",
+				"when": "canNavigateBack"
 			},
 			{
 				"key": "ctrl+shift+-",
-				"command": "workbench.action.navigateForward"
+				"command": "workbench.action.navigateForward",
+				"when": "canNavigateForward"
 			},
 			{
 				"key": "cmd+k cmd+q",
@@ -1792,12 +3824,22 @@
 				"command": "workbench.action.openGlobalKeybindings"
 			},
 			{
+				"key": "ctrl+r",
+				"command": "workbench.action.openRecent"
+			},
+			{
 				"key": "cmd+,",
 				"command": "workbench.action.openSettings"
 			},
 			{
 				"key": "shift+cmd+u",
-				"command": "workbench.action.output.toggleOutput"
+				"command": "workbench.action.output.toggleOutput",
+				"when": "workbench.panel.output.active"
+			},
+			{
+				"key": "cmd+k shift+enter",
+				"command": "workbench.action.pinEditor",
+				"when": "!activeEditorIsPinned"
 			},
 			{
 				"key": "shift+cmd+[",
@@ -1816,16 +3858,31 @@
 				"command": "workbench.action.quickOpen"
 			},
 			{
+				"key": "ctrl+shift+tab",
+				"command": "workbench.action.quickOpenLeastRecentlyUsedEditorInGroup",
+				"when": "!activeEditorGroupEmpty"
+			},
+			{
 				"key": "ctrl+tab",
-				"command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup"
+				"command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup",
+				"when": "!activeEditorGroupEmpty"
 			},
 			{
 				"key": "ctrl+q",
 				"command": "workbench.action.quickOpenView"
 			},
 			{
+				"key": "shift+cmd+i",
+				"command": "workbench.action.quickchat.toggle",
+				"when": "chatIsEnabled"
+			},
+			{
 				"key": "cmd+q",
 				"command": "workbench.action.quit"
+			},
+			{
+				"key": "alt+cmd+o",
+				"command": "workbench.action.remote.showMenu"
 			},
 			{
 				"key": "shift+cmd+t",
@@ -1853,6 +3910,10 @@
 				"command": "workbench.action.showAllSymbols"
 			},
 			{
+				"key": "f1",
+				"command": "workbench.action.showCommands"
+			},
+			{
 				"key": "shift+cmd+p",
 				"command": "workbench.action.showCommands"
 			},
@@ -1862,7 +3923,28 @@
 			},
 			{
 				"key": "cmd+k cmd+\\",
+				"command": "workbench.action.splitEditorDown"
+			},
+			{
+				"key": "cmd+k shift+cmd+\\",
+				"command": "workbench.action.splitEditorInGroup",
+				"when": "activeEditorCanSplitInGroup"
+			},
+			{
+				"key": "cmd+k cmd+\\",
+				"command": "workbench.action.splitEditorLeft"
+			},
+			{
+				"key": "cmd+k cmd+\\",
 				"command": "workbench.action.splitEditorOrthogonal"
+			},
+			{
+				"key": "cmd+k cmd+\\",
+				"command": "workbench.action.splitEditorRight"
+			},
+			{
+				"key": "cmd+k cmd+\\",
+				"command": "workbench.action.splitEditorUp"
 			},
 			{
 				"key": "ctrl+w",
@@ -1870,161 +3952,213 @@
 			},
 			{
 				"key": "shift+cmd+b",
-				"command": "workbench.action.tasks.build"
+				"command": "workbench.action.tasks.build",
+				"when": "taskCommandsRegistered"
+			},
+			{
+				"key": "shift+escape",
+				"command": "workbench.action.terminal.chat.close",
+				"when": "terminalChatFocus && terminalChatVisible"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.terminal.chat.close",
+				"when": "terminalChatFocus && terminalChatVisible"
+			},
+			{
+				"key": "cmd+i",
+				"command": "workbench.action.terminal.chat.focusInput",
+				"when": "terminalChatFocus && !inlineChatFocused"
+			},
+			{
+				"key": "cmd+up",
+				"command": "workbench.action.terminal.chat.focusInput",
+				"when": "terminalChatFocus && !inlineChatFocused"
+			},
+			{
+				"key": "cmd+down",
+				"command": "workbench.action.terminal.chat.focusResponse",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "alt+cmd+enter",
+				"command": "workbench.action.terminal.chat.insertCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "alt+enter",
+				"command": "workbench.action.terminal.chat.insertCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "alt+cmd+enter",
+				"command": "workbench.action.terminal.chat.insertFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
+			},
+			{
+				"key": "alt+enter",
+				"command": "workbench.action.terminal.chat.insertFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.terminal.chat.makeRequest",
+				"when": "terminalChatFocus && terminalHasBeenCreated && !inlineChatEmpty && !terminalChatActiveRequest || terminalChatFocus && terminalProcessSupported && !inlineChatEmpty && !terminalChatActiveRequest"
+			},
+			{
+				"key": "down",
+				"command": "workbench.action.terminal.chat.nextFromHistory",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "up",
+				"command": "workbench.action.terminal.chat.previousFromHistory",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "workbench.action.terminal.chat.runCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "workbench.action.terminal.chat.runFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
 			},
 			{
 				"key": "escape",
 				"command": "workbench.action.terminal.clearSelection",
-				"when": "terminalFocus && terminalTextSelected && !terminalFindWidgetVisible"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && terminalTextSelected && !terminalFindVisible || terminalFocusInAny && terminalProcessSupported && terminalTextSelected && !terminalFindVisible"
 			},
 			{
 				"key": "cmd+c",
 				"command": "workbench.action.terminal.copySelection",
-				"when": "terminalFocus && terminalTextSelected"
+				"when": "terminalTextSelectedInFocused || terminalFocus && terminalHasBeenCreated && terminalTextSelected || terminalFocus && terminalProcessSupported && terminalTextSelected || terminalFocus && terminalTextSelected && terminalTextSelectedInFocused || terminalHasBeenCreated && terminalTextSelected && terminalTextSelectedInFocused || terminalProcessSupported && terminalTextSelected && terminalTextSelectedInFocused"
 			},
 			{
-				"key": "cmd+backspace",
-				"command": "workbench.action.terminal.deleteToLineStart",
-				"when": "terminalFocus"
+				"key": "f3",
+				"command": "workbench.action.terminal.findNext",
+				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
 			},
 			{
-				"key": "alt+backspace",
-				"command": "workbench.action.terminal.deleteWordLeft",
-				"when": "terminalFocus"
-			},
-			{
-				"key": "alt+delete",
-				"command": "workbench.action.terminal.deleteWordRight",
-				"when": "terminalFocus"
+				"key": "cmd+g",
+				"command": "workbench.action.terminal.findNext",
+				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
 			},
 			{
 				"key": "shift+enter",
 				"command": "workbench.action.terminal.findNext",
-				"when": "terminalFindWidgetFocused"
+				"when": "terminalFindInputFocused && terminalHasBeenCreated || terminalFindInputFocused && terminalProcessSupported"
 			},
 			{
-				"key": "f3",
-				"command": "workbench.action.terminal.findNext",
-				"when": "terminalFocus"
+				"key": "shift+f3",
+				"command": "workbench.action.terminal.findPrevious",
+				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
 			},
 			{
-				"key": "f3",
-				"command": "workbench.action.terminal.findNext",
-				"when": "terminalFindWidgetFocused"
-			},
-			{
-				"key": "cmd+g",
-				"command": "workbench.action.terminal.findNext",
-				"when": "terminalFocus"
-			},
-			{
-				"key": "cmd+g",
-				"command": "workbench.action.terminal.findNext",
-				"when": "terminalFindWidgetFocused"
+				"key": "shift+cmd+g",
+				"command": "workbench.action.terminal.findPrevious",
+				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
 			},
 			{
 				"key": "enter",
 				"command": "workbench.action.terminal.findPrevious",
-				"when": "terminalFindWidgetFocused"
+				"when": "terminalFindInputFocused && terminalHasBeenCreated || terminalFindInputFocused && terminalProcessSupported"
 			},
 			{
-				"key": "shift+f3",
-				"command": "workbench.action.terminal.findPrevious",
-				"when": "terminalFocus"
+				"key": "cmd+down",
+				"command": "workbench.action.terminal.focus",
+				"when": "accessibilityModeEnabled && accessibleViewOnLastLine && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibilityModeEnabled && accessibleViewOnLastLine && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
 			},
 			{
-				"key": "shift+f3",
-				"command": "workbench.action.terminal.findPrevious",
-				"when": "terminalFindWidgetFocused"
+				"key": "cmd+up",
+				"command": "workbench.action.terminal.focusAccessibleBuffer",
+				"when": "accessibilityModeEnabled && terminalFocus && terminalHasBeenCreated || accessibilityModeEnabled && terminalFocus && terminalProcessSupported"
 			},
 			{
-				"key": "shift+cmd+g",
-				"command": "workbench.action.terminal.findPrevious",
-				"when": "terminalFocus"
-			},
-			{
-				"key": "shift+cmd+g",
-				"command": "workbench.action.terminal.findPrevious",
-				"when": "terminalFindWidgetFocused"
+				"key": "alt+f2",
+				"command": "workbench.action.terminal.focusAccessibleBuffer",
+				"when": "accessibilityModeEnabled && terminalFocus && terminalHasBeenCreated || accessibilityModeEnabled && terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "cmd+f",
-				"command": "workbench.action.terminal.focusFindWidget",
-				"when": "terminalFocus"
+				"command": "workbench.action.terminal.focusFind",
+				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
 			},
 			{
-				"key": "cmd+f",
-				"command": "workbench.action.terminal.focusFindWidget",
-				"when": "terminalFindWidgetFocused"
+				"key": "cmd+k cmd+i",
+				"command": "workbench.action.terminal.focusHover",
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalIsOpen || terminalFocus && terminalProcessSupported || terminalHasBeenCreated && terminalTabsFocus || terminalIsOpen && terminalTabsFocus || terminalProcessSupported && terminalTabsFocus"
+			},
+			{
+				"key": "shift+cmd+]",
+				"command": "workbench.action.terminal.focusNext",
+				"when": "terminalFocus && terminalHasBeenCreated && !terminalEditorFocus || terminalFocus && terminalProcessSupported && !terminalEditorFocus"
 			},
 			{
 				"key": "alt+cmd+down",
 				"command": "workbench.action.terminal.focusNextPane",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "alt+cmd+right",
 				"command": "workbench.action.terminal.focusNextPane",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
+			},
+			{
+				"key": "shift+cmd+[",
+				"command": "workbench.action.terminal.focusPrevious",
+				"when": "terminalFocus && terminalHasBeenCreated && !terminalEditorFocus || terminalFocus && terminalProcessSupported && !terminalEditorFocus"
 			},
 			{
 				"key": "alt+cmd+up",
 				"command": "workbench.action.terminal.focusPreviousPane",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "alt+cmd+left",
 				"command": "workbench.action.terminal.focusPreviousPane",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
+			},
+			{
+				"key": "shift+cmd+\\",
+				"command": "workbench.action.terminal.focusTabs",
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported || terminalHasBeenCreated && terminalTabsFocus || terminalProcessSupported && terminalTabsFocus"
+			},
+			{
+				"key": "cmd+g",
+				"command": "workbench.action.terminal.goToRecentDirectory",
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "shift+escape",
-				"command": "workbench.action.terminal.hideFindWidget",
-				"when": "terminalFindWidgetVisible && terminalFocus"
+				"command": "workbench.action.terminal.hideFind",
+				"when": "terminalFindVisible && terminalFocusInAny && terminalHasBeenCreated || terminalFindVisible && terminalFocusInAny && terminalProcessSupported"
 			},
 			{
 				"key": "escape",
-				"command": "workbench.action.terminal.hideFindWidget",
-				"when": "terminalFindWidgetVisible && terminalFocus"
+				"command": "workbench.action.terminal.hideFind",
+				"when": "terminalFindVisible && terminalFocusInAny && terminalHasBeenCreated || terminalFindVisible && terminalFocusInAny && terminalProcessSupported"
 			},
 			{
-				"key": "cmd+right",
-				"command": "workbench.action.terminal.moveToLineEnd",
-				"when": "terminalFocus"
+				"key": "delete",
+				"command": "workbench.action.terminal.killActiveTab",
+				"when": "terminalHasBeenCreated && terminalTabsFocus || terminalIsOpen && terminalTabsFocus || terminalProcessSupported && terminalTabsFocus"
 			},
 			{
-				"key": "cmd+left",
-				"command": "workbench.action.terminal.moveToLineStart",
-				"when": "terminalFocus"
+				"key": "cmd+backspace",
+				"command": "workbench.action.terminal.killActiveTab",
+				"when": "terminalHasBeenCreated && terminalTabsFocus || terminalIsOpen && terminalTabsFocus || terminalProcessSupported && terminalTabsFocus"
 			},
 			{
-				"key": "escape",
-				"command": "workbench.action.terminal.navigationModeExit",
-				"when": "accessibilityModeEnabled && terminalA11yTreeFocus"
-			},
-			{
-				"key": "cmd+down",
-				"command": "workbench.action.terminal.navigationModeFocusNext",
-				"when": "accessibilityModeEnabled && terminalFocus"
-			},
-			{
-				"key": "cmd+down",
-				"command": "workbench.action.terminal.navigationModeFocusNext",
-				"when": "accessibilityModeEnabled && terminalA11yTreeFocus"
-			},
-			{
-				"key": "cmd+up",
-				"command": "workbench.action.terminal.navigationModeFocusPrevious",
-				"when": "accessibilityModeEnabled && terminalFocus"
-			},
-			{
-				"key": "cmd+up",
-				"command": "workbench.action.terminal.navigationModeFocusPrevious",
-				"when": "accessibilityModeEnabled && terminalA11yTreeFocus"
+				"key": "cmd+w",
+				"command": "workbench.action.terminal.killEditor",
+				"when": "terminalEditorFocus && terminalFocus && terminalHasBeenCreated || terminalEditorFocus && terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+shift+`",
-				"command": "workbench.action.terminal.new"
+				"command": "workbench.action.terminal.new",
+				"when": "terminalProcessSupported || terminalWebExtensionContributedProfile"
 			},
 			{
 				"key": "shift+cmd+c",
@@ -2034,126 +4168,289 @@
 			{
 				"key": "cmd+v",
 				"command": "workbench.action.terminal.paste",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.terminal.renameActiveTab",
+				"when": "terminalHasBeenCreated && terminalTabsFocus && terminalTabsSingularSelection || terminalProcessSupported && terminalTabsFocus && terminalTabsSingularSelection"
 			},
 			{
 				"key": "ctrl+cmd+down",
 				"command": "workbench.action.terminal.resizePaneDown",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+cmd+left",
 				"command": "workbench.action.terminal.resizePaneLeft",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+cmd+right",
 				"command": "workbench.action.terminal.resizePaneRight",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+cmd+up",
 				"command": "workbench.action.terminal.resizePaneUp",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
+			},
+			{
+				"key": "cmd+r",
+				"command": "workbench.action.terminal.runRecentCommand",
+				"when": "accessibilityModeEnabled && terminalFocus && terminalHasBeenCreated || accessibilityModeEnabled && terminalFocus && terminalProcessSupported || accessibilityModeEnabled && accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibilityModeEnabled && accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
+			},
+			{
+				"key": "ctrl+alt+r",
+				"command": "workbench.action.terminal.runRecentCommand",
+				"when": "terminalFocus && terminalHasBeenCreated && !accessibilityModeEnabled || terminalFocus && terminalProcessSupported && !accessibilityModeEnabled"
 			},
 			{
 				"key": "alt+cmd+pagedown",
 				"command": "workbench.action.terminal.scrollDown",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && !terminalAltBufferActive || terminalFocusInAny && terminalProcessSupported && !terminalAltBufferActive"
 			},
 			{
 				"key": "pagedown",
 				"command": "workbench.action.terminal.scrollDownPage",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && !terminalAltBufferActive || terminalFocusInAny && terminalProcessSupported && !terminalAltBufferActive"
 			},
 			{
 				"key": "cmd+end",
 				"command": "workbench.action.terminal.scrollToBottom",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && !terminalAltBufferActive || terminalFocusInAny && terminalProcessSupported && !terminalAltBufferActive"
+			},
+			{
+				"key": "cmd+end",
+				"command": "workbench.action.terminal.scrollToBottomAccessibleView",
+				"when": "accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
 			},
 			{
 				"key": "cmd+down",
 				"command": "workbench.action.terminal.scrollToNextCommand",
-				"when": "terminalFocus && !accessibilityModeEnabled"
+				"when": "terminalFocus && terminalHasBeenCreated && !accessibilityModeEnabled || terminalFocus && terminalProcessSupported && !accessibilityModeEnabled"
 			},
 			{
 				"key": "cmd+up",
 				"command": "workbench.action.terminal.scrollToPreviousCommand",
-				"when": "terminalFocus && !accessibilityModeEnabled"
+				"when": "terminalFocus && terminalHasBeenCreated && !accessibilityModeEnabled || terminalFocus && terminalProcessSupported && !accessibilityModeEnabled"
 			},
 			{
 				"key": "cmd+home",
 				"command": "workbench.action.terminal.scrollToTop",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && !terminalAltBufferActive || terminalFocusInAny && terminalProcessSupported && !terminalAltBufferActive"
+			},
+			{
+				"key": "cmd+home",
+				"command": "workbench.action.terminal.scrollToTopAccessibleView",
+				"when": "accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
 			},
 			{
 				"key": "alt+cmd+pageup",
 				"command": "workbench.action.terminal.scrollUp",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && !terminalAltBufferActive || terminalFocusInAny && terminalProcessSupported && !terminalAltBufferActive"
 			},
 			{
 				"key": "pageup",
 				"command": "workbench.action.terminal.scrollUpPage",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated && !terminalAltBufferActive || terminalFocusInAny && terminalProcessSupported && !terminalAltBufferActive"
 			},
 			{
 				"key": "cmd+a",
 				"command": "workbench.action.terminal.selectAll",
-				"when": "terminalFocus"
+				"when": "terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
 			},
 			{
 				"key": "shift+cmd+down",
 				"command": "workbench.action.terminal.selectToNextCommand",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
 			},
 			{
 				"key": "shift+cmd+up",
 				"command": "workbench.action.terminal.selectToPreviousCommand",
+				"when": "terminalFocus && terminalHasBeenCreated || terminalFocus && terminalProcessSupported"
+			},
+			{
+				"key": "ctrl+space",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"args": {
+					"text": "\u001b[24~a"
+				}
+			},
+			{
+				"key": "alt+space",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"args": {
+					"text": "\u001b[24~b"
+				}
+			},
+			{
+				"key": "shift+enter",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"args": {
+					"text": "\u001b[24~c"
+				}
+			},
+			{
+				"key": "shift+cmd+right",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"args": {
+					"text": "\u001b[24~d"
+				}
+			},
+			{
+				"key": "ctrl+space",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "config.terminal.integrated.suggest.enabled && terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"args": {
+					"text": "\u001b[24~e"
+				}
+			},
+			{
+				"key": "shift+cmd+left",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus && terminalShellType == 'pwsh'",
+				"args": {
+					"text": "\u001b[1;2H"
+				}
+			},
+			{
+				"key": "ctrl+alt+r",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "accessibilityModeEnabled && terminalFocus",
+				"args": {
+					"text": "\u0012"
+				}
+			},
+			{
+				"key": "ctrl+alt+g",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u0007"
+				}
+			},
+			{
+				"key": "alt+backspace",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u0017"
+				}
+			},
+			{
+				"key": "alt+delete",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u001bd"
+				}
+			},
+			{
+				"key": "cmd+backspace",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u0015"
+				}
+			},
+			{
+				"key": "cmd+left",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u0001"
+				}
+			},
+			{
+				"key": "cmd+right",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u0005"
+				}
+			},
+			{
+				"key": "ctrl+shift+2",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u0000"
+				}
+			},
+			{
+				"key": "ctrl+shift+6",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u001e"
+				}
+			},
+			{
+				"key": "ctrl+/",
+				"command": "workbench.action.terminal.sendSequence",
+				"when": "terminalFocus",
+				"args": {
+					"text": "\u001f"
+				}
+			},
+			{
+				"key": "cmd+.",
+				"command": "workbench.action.terminal.showQuickFixes",
 				"when": "terminalFocus"
+			},
+			{
+				"key": "alt+z",
+				"command": "workbench.action.terminal.sizeToContentWidth",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen || terminalFocus && terminalIsOpen && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+shift+5",
 				"command": "workbench.action.terminal.split",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalProcessSupported || terminalFocus && terminalWebExtensionContributedProfile"
 			},
 			{
 				"key": "cmd+\\",
 				"command": "workbench.action.terminal.split",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalProcessSupported || terminalFocus && terminalWebExtensionContributedProfile"
+			},
+			{
+				"key": "ctrl+shift+5",
+				"command": "workbench.action.terminal.splitActiveTab",
+				"when": "terminalProcessSupported && terminalTabsFocus"
+			},
+			{
+				"key": "cmd+\\",
+				"command": "workbench.action.terminal.splitActiveTab",
+				"when": "terminalProcessSupported && terminalTabsFocus"
 			},
 			{
 				"key": "alt+cmd+c",
 				"command": "workbench.action.terminal.toggleFindCaseSensitive",
-				"when": "terminalFindWidgetFocused"
-			},
-			{
-				"key": "alt+cmd+c",
-				"command": "workbench.action.terminal.toggleFindCaseSensitive",
-				"when": "terminalFocus"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "alt+cmd+r",
 				"command": "workbench.action.terminal.toggleFindRegex",
-				"when": "terminalFindWidgetFocused"
-			},
-			{
-				"key": "alt+cmd+r",
-				"command": "workbench.action.terminal.toggleFindRegex",
-				"when": "terminalFocus"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "alt+cmd+w",
 				"command": "workbench.action.terminal.toggleFindWholeWord",
-				"when": "terminalFindWidgetFocused"
-			},
-			{
-				"key": "alt+cmd+w",
-				"command": "workbench.action.terminal.toggleFindWholeWord",
-				"when": "terminalFocus"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+`",
-				"command": "workbench.action.terminal.toggleTerminal"
+				"command": "workbench.action.terminal.toggleTerminal",
+				"when": "terminal.active"
+			},
+			{
+				"key": "alt+cmd+b",
+				"command": "workbench.action.toggleAuxiliaryBar"
 			},
 			{
 				"key": "alt+cmd+0",
@@ -2161,7 +4458,13 @@
 			},
 			{
 				"key": "ctrl+cmd+f",
-				"command": "workbench.action.toggleFullScreen"
+				"command": "workbench.action.toggleFullScreen",
+				"when": "!isIOS"
+			},
+			{
+				"key": "cmd+k cmd+m",
+				"command": "workbench.action.toggleMaximizeEditorGroup",
+				"when": "editorPartMaximizedEditorGroup || editorPartMultipleEditorGroups"
 			},
 			{
 				"key": "cmd+j",
@@ -2172,12 +4475,14 @@
 				"command": "workbench.action.toggleSidebarVisibility"
 			},
 			{
-				"key": "ctrl+cmd+w",
-				"command": "workbench.action.toggleTabsVisibility"
+				"key": "cmd+k z",
+				"command": "workbench.action.toggleZenMode",
+				"when": "!isAuxiliaryWindowFocusedContext"
 			},
 			{
-				"key": "cmd+k z",
-				"command": "workbench.action.toggleZenMode"
+				"key": "cmd+k shift+enter",
+				"command": "workbench.action.unpinEditor",
+				"when": "activeEditorIsPinned"
 			},
 			{
 				"key": "cmd+numpad_add",
@@ -2209,15 +4514,38 @@
 			},
 			{
 				"key": "shift+cmd+m",
-				"command": "workbench.actions.view.problems"
+				"command": "workbench.actions.view.problems",
+				"when": "workbench.panel.markers.view.active"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.banner.focusBanner",
+				"when": "bannerFocused"
+			},
+			{
+				"key": "down",
+				"command": "workbench.banner.focusNextAction",
+				"when": "bannerFocused"
+			},
+			{
+				"key": "right",
+				"command": "workbench.banner.focusNextAction",
+				"when": "bannerFocused"
+			},
+			{
+				"key": "up",
+				"command": "workbench.banner.focusPreviousAction",
+				"when": "bannerFocused"
+			},
+			{
+				"key": "left",
+				"command": "workbench.banner.focusPreviousAction",
+				"when": "bannerFocused"
 			},
 			{
 				"key": "shift+cmd+y",
-				"command": "workbench.debug.action.toggleRepl"
-			},
-			{
-				"key": "cmd+k cmd+m",
-				"command": "workbench.extensions.action.showRecommendedKeymapExtensions"
+				"command": "workbench.debug.action.toggleRepl",
+				"when": "workbench.panel.repl.view.active"
 			},
 			{
 				"key": "cmd+k c",
@@ -2233,40 +4561,199 @@
 				"when": "workbench.explorer.openEditorsView.active"
 			},
 			{
+				"key": "escape",
+				"command": "workbench.statusBar.clearFocus",
+				"when": "statusBarFocused"
+			},
+			{
+				"key": "home",
+				"command": "workbench.statusBar.focusFirst",
+				"when": "statusBarFocused"
+			},
+			{
+				"key": "end",
+				"command": "workbench.statusBar.focusLast",
+				"when": "statusBarFocused"
+			},
+			{
+				"key": "down",
+				"command": "workbench.statusBar.focusNext",
+				"when": "statusBarFocused"
+			},
+			{
+				"key": "right",
+				"command": "workbench.statusBar.focusNext",
+				"when": "statusBarFocused"
+			},
+			{
+				"key": "up",
+				"command": "workbench.statusBar.focusPrevious",
+				"when": "statusBarFocused"
+			},
+			{
+				"key": "left",
+				"command": "workbench.statusBar.focusPrevious",
+				"when": "statusBarFocused"
+			},
+			{
 				"key": "shift+cmd+d",
-				"command": "workbench.view.debug"
+				"command": "workbench.view.debug",
+				"when": "viewContainer.workbench.view.debug.enabled"
 			},
 			{
 				"key": "shift+cmd+e",
-				"command": "workbench.view.explorer"
+				"command": "workbench.view.explorer",
+				"when": "viewContainer.workbench.view.explorer.enabled"
 			},
 			{
 				"key": "shift+cmd+x",
-				"command": "workbench.view.extensions"
+				"command": "workbench.view.extensions",
+				"when": "viewContainer.workbench.view.extensions.enabled"
 			},
 			{
 				"key": "ctrl+shift+g",
-				"command": "workbench.view.scm"
+				"command": "workbench.view.scm",
+				"when": "workbench.scm.active"
 			},
 			{
 				"key": "shift+cmd+f",
 				"command": "workbench.view.search",
-				"when": "!searchViewletVisible"
+				"when": "workbench.view.search.active && neverMatch =~ /doesNotMatch/"
 			},
 			{
 				"key": "alt+right",
 				"command": "breadcrumbs.focusNextWithPicker",
-				"when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus"
+				"when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus && !treestickyScrollFocused"
 			},
 			{
 				"key": "alt+left",
 				"command": "breadcrumbs.focusPreviousWithPicker",
-				"when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus"
+				"when": "breadcrumbsActive && breadcrumbsVisible && listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
+				"key": "escape",
+				"command": "breadcrumbs.selectEditor",
+				"when": "breadcrumbsActive && breadcrumbsVisible"
+			},
+			{
+				"key": "down",
+				"command": "notebook.cell.nullAction",
+				"when": "notebookOutputInputFocused"
+			},
+			{
+				"key": "up",
+				"command": "notebook.cell.nullAction",
+				"when": "notebookOutputInputFocused"
+			},
+			{
+				"key": "cmd+a",
+				"command": "notebook.cell.output.selectAll",
+				"when": "notebookEditorFocused && notebookOutputFocused"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "notebook.focusNextEditor",
+				"when": "accessibilityModeEnabled && notebookCellEditorFocused"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "notebook.focusPreviousEditor",
+				"when": "accessibilityModeEnabled && notebookCellEditorFocused"
+			},
+			{
+				"key": "cmd+k down",
+				"command": "views.moveViewDown",
+				"when": "focusedView != ''"
+			},
+			{
+				"key": "cmd+k left",
+				"command": "views.moveViewLeft",
+				"when": "focusedView != ''"
+			},
+			{
+				"key": "cmd+k right",
+				"command": "views.moveViewRight",
+				"when": "focusedView != ''"
+			},
+			{
+				"key": "cmd+k up",
+				"command": "views.moveViewUp",
+				"when": "focusedView != ''"
+			},
+			{
+				"key": "shift+cmd+]",
+				"command": "workbench.action.debug.nextConsole",
+				"when": "inDebugRepl"
+			},
+			{
+				"key": "shift+cmd+[",
+				"command": "workbench.action.debug.prevConsole",
+				"when": "inDebugRepl"
+			},
+			{
+				"key": "tab",
+				"command": "workbench.action.terminal.acceptSelectedSuggestion",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.terminal.acceptSelectedSuggestion",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
 			},
 			{
 				"key": "cmd+k",
 				"command": "workbench.action.terminal.clear",
-				"when": "terminalFocus"
+				"when": "terminalFocus && terminalHasBeenCreated && !accessibilityModeEnabled || terminalFocus && terminalProcessSupported && !accessibilityModeEnabled || accessibilityModeEnabled && accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibilityModeEnabled && accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.terminal.hideSuggestWidget",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
+			},
+			{
+				"key": "shift+cmd+o",
+				"command": "workbench.action.terminal.openDetectedLink",
+				"when": "terminalFocus && terminalHasBeenCreated"
+			},
+			{
+				"key": "shift+cmd+g",
+				"command": "workbench.action.terminal.openDetectedLink",
+				"when": "accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal'"
+			},
+			{
+				"key": "pagedown",
+				"command": "workbench.action.terminal.selectNextPageSuggestion",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
+			},
+			{
+				"key": "down",
+				"command": "workbench.action.terminal.selectNextSuggestion",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
+			},
+			{
+				"key": "pageup",
+				"command": "workbench.action.terminal.selectPrevPageSuggestion",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
+			},
+			{
+				"key": "up",
+				"command": "workbench.action.terminal.selectPrevSuggestion",
+				"when": "terminalFocus && terminalHasBeenCreated && terminalIsOpen && terminalSuggestWidgetVisible || terminalFocus && terminalIsOpen && terminalProcessSupported && terminalSuggestWidgetVisible"
+			},
+			{
+				"key": "f6",
+				"command": "workbench.action.debug.pause",
+				"when": "debugState == 'running'"
+			},
+			{
+				"key": "alt+down",
+				"command": "workbench.action.terminal.accessibleBufferGoToNextCommand",
+				"when": "accessibleViewIsShown && accessibleViewCurrentProviderId == 'terminal' || accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
+			},
+			{
+				"key": "alt+up",
+				"command": "workbench.action.terminal.accessibleBufferGoToPreviousCommand",
+				"when": "accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
 			},
 			{
 				"key": "enter",
@@ -2279,44 +4766,123 @@
 				"when": "variablesFocused"
 			},
 			{
-				"key": "alt+cmd+backspace",
-				"command": "deleteFile",
-				"when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceReadonly && !inputFocus"
+				"key": "space",
+				"command": "debug.toggleBreakpoint",
+				"when": "breakpointsFocused && !inputFocus"
 			},
 			{
-				"key": "cmd+backspace",
-				"command": "deleteFile",
-				"when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceMoveableToTrash && !explorerResourceReadonly && !inputFocus"
-			},
-			{
-				"key": "cmd+c",
-				"command": "filesExplorer.copy",
-				"when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !inputFocus"
-			},
-			{
-				"key": "cmd+x",
-				"command": "filesExplorer.cut",
-				"when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !inputFocus"
+				"key": "escape",
+				"command": "notebook.cell.quitEdit",
+				"when": "notebookEditorFocused && notebookOutputFocused"
 			},
 			{
 				"key": "cmd+v",
 				"command": "filesExplorer.paste",
-				"when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceReadonly && !inputFocus"
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceReadonly && !inputFocus"
+			},
+			{
+				"key": "alt+cmd+backspace",
+				"command": "deleteFile",
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceReadonly && !inputFocus"
+			},
+			{
+				"key": "cmd+backspace",
+				"command": "deleteFile",
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceMoveableToTrash && !explorerResourceReadonly && !inputFocus"
+			},
+			{
+				"key": "shift+cmd+.",
+				"command": "editor.action.accessibleViewGoToSymbol",
+				"when": "accessibilityHelpIsShown && accessibleViewGoToSymbolSupported || accessibleViewGoToSymbolSupported && accessibleViewIsShown"
+			},
+			{
+				"key": "shift+cmd+o",
+				"command": "editor.action.accessibleViewGoToSymbol",
+				"when": "accessibilityHelpIsShown && accessibleViewGoToSymbolSupported || accessibleViewGoToSymbolSupported && accessibleViewIsShown"
+			},
+			{
+				"key": "cmd+e",
+				"command": "editor.action.toggleScreenReaderAccessibilityMode",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
+				"key": "shift+alt+f1",
+				"command": "editor.action.toggleScreenReaderAccessibilityMode"
+			},
+			{
+				"key": "escape",
+				"command": "editor.closeCallHierarchy",
+				"when": "callHierarchyVisible && !config.editor.stablePeek"
+			},
+			{
+				"key": "escape",
+				"command": "editor.closeTypeHierarchy",
+				"when": "typeHierarchyVisible && !config.editor.stablePeek"
+			},
+			{
+				"key": "cmd+down",
+				"command": "explorer.openAndPassFocus",
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceIsFolder && !inputFocus"
+			},
+			{
+				"key": "escape",
+				"command": "filesExplorer.cancelCut",
+				"when": "explorerResourceCut && filesExplorerFocus && foldersViewVisible && !inputFocus"
+			},
+			{
+				"key": "cmd+c",
+				"command": "filesExplorer.copy",
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceIsRoot && !inputFocus"
+			},
+			{
+				"key": "cmd+x",
+				"command": "filesExplorer.cut",
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceIsRoot && !explorerResourceReadonly && !inputFocus"
+			},
+			{
+				"key": "space",
+				"command": "filesExplorer.openFilePreserveFocus",
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceIsFolder && !inputFocus"
+			},
+			{
+				"key": "home",
+				"command": "firstCompressedFolder",
+				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedFirstFocus && !inputFocus"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "inlineChat.acceptChanges",
+				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.mode != 'preview'"
 			},
 			{
 				"key": "end",
 				"command": "lastCompressedFolder",
-				"when": "explorerViewletCompressedFocus && explorerViewletVisible && filesExplorerFocus && !explorerViewletCompressedLastFocus && !inputFocus"
+				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedLastFocus && !inputFocus"
+			},
+			{
+				"key": "delete",
+				"command": "moveFileToTrash",
+				"when": "explorerResourceMoveableToTrash && filesExplorerFocus && foldersViewVisible && !explorerResourceReadonly && !inputFocus"
 			},
 			{
 				"key": "cmd+backspace",
 				"command": "moveFileToTrash",
-				"when": "explorerResourceMoveableToTrash && explorerViewletVisible && filesExplorerFocus && !explorerResourceReadonly && !inputFocus"
+				"when": "explorerResourceMoveableToTrash && filesExplorerFocus && foldersViewVisible && !explorerResourceReadonly && !inputFocus"
+			},
+			{
+				"key": "right",
+				"command": "nextCompressedFolder",
+				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedLastFocus && !inputFocus"
 			},
 			{
 				"key": "left",
 				"command": "previousCompressedFolder",
-				"when": "explorerViewletCompressedFocus && explorerViewletVisible && filesExplorerFocus && !explorerViewletCompressedFirstFocus && !inputFocus"
+				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedFirstFocus && !inputFocus"
+			},
+			{
+				"key": "delete",
+				"command": "remote.tunnel.closeInline",
+				"when": "tunnelCloseable && tunnelViewFocus"
 			},
 			{
 				"key": "cmd+backspace",
@@ -2326,22 +4892,62 @@
 			{
 				"key": "cmd+c",
 				"command": "remote.tunnel.copyAddressInline",
-				"when": "tunnelViewFocus && tunnelType == 'Detected' || tunnelViewFocus && tunnelType == 'Forwarded'"
+				"when": "tunnelViewFocus && tunnelType == 'Detected' && tunnelViewMultiSelection == 'undefined' || tunnelViewFocus && tunnelType == 'Forwarded' && tunnelViewMultiSelection == 'undefined'"
 			},
 			{
 				"key": "enter",
 				"command": "remote.tunnel.label",
-				"when": "tunnelViewFocus && tunnelType == 'Forwarded'"
+				"when": "tunnelViewFocus && tunnelType == 'Forwarded' && tunnelViewMultiSelection == 'undefined'"
 			},
 			{
 				"key": "enter",
 				"command": "renameFile",
-				"when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !explorerResourceReadonly && !inputFocus"
+				"when": "filesExplorerFocus && foldersViewVisible && !explorerResourceIsRoot && !explorerResourceReadonly && !inputFocus"
+			},
+			{
+				"key": "f5",
+				"command": "workbench.action.debug.continue",
+				"when": "debugState == 'stopped'"
+			},
+			{
+				"key": "f11",
+				"command": "workbench.action.debug.stepInto",
+				"when": "debugState != 'inactive'"
 			},
 			{
 				"key": "shift+escape",
 				"command": "closeReferenceSearch",
-				"when": "referenceSearchVisible && !config.editor.stablePeek"
+				"when": "editorTextFocus && referenceSearchVisible && !config.editor.stablePeek || referenceSearchVisible && !config.editor.stablePeek && !inputFocus"
+			},
+			{
+				"key": "escape",
+				"command": "closeReferenceSearch",
+				"when": "editorTextFocus && referenceSearchVisible && !config.editor.stablePeek || referenceSearchVisible && !config.editor.stablePeek && !inputFocus"
+			},
+			{
+				"key": "cmd+up",
+				"command": "list.stickyScroll.collapse",
+				"when": "treestickyScrollFocused"
+			},
+			{
+				"key": "left",
+				"command": "list.stickyScroll.collapse",
+				"when": "treestickyScrollFocused"
+			},
+			{
+				"key": "cmd+down",
+				"command": "list.stickyScrollselect",
+				"when": "treestickyScrollFocused"
+			},
+			{
+				"key": "enter",
+				"command": "list.stickyScrollselect",
+				"when": "treestickyScrollFocused"
+			},
+			{
+				"key": "space",
+				"command": "list.stickyScrolltoggleExpand",
+				"when": "treestickyScrollFocused"
 			},
 			{
 				"key": "escape",
@@ -2349,9 +4955,44 @@
 				"when": "notificationCenterVisible"
 			},
 			{
-				"key": "escape",
-				"command": "notifications.hideToasts",
-				"when": "notificationToastsVisible"
+				"key": "ctrl+alt+cmd+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+cmd+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+cmd+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "cmd+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
 			},
 			{
 				"key": "ctrl+-",
@@ -2359,9 +5000,19 @@
 				"when": "inQuickOpen"
 			},
 			{
+				"key": "ctrl+tab",
+				"command": "workbench.action.quickOpenNavigateNextInEditorPicker",
+				"when": "inEditorsPicker && inQuickOpen"
+			},
+			{
 				"key": "cmd+p",
 				"command": "workbench.action.quickOpenNavigateNextInFilePicker",
 				"when": "inFilesPicker && inQuickOpen"
+			},
+			{
+				"key": "ctrl+r",
+				"command": "workbench.action.quickOpenNavigateNextInRecentFilesPicker",
+				"when": "inQuickOpen && inRecentFilesPicker"
 			},
 			{
 				"key": "ctrl+q",
@@ -2369,9 +5020,19 @@
 				"when": "inQuickOpen && inViewsPicker"
 			},
 			{
+				"key": "ctrl+shift+tab",
+				"command": "workbench.action.quickOpenNavigatePreviousInEditorPicker",
+				"when": "inEditorsPicker && inQuickOpen"
+			},
+			{
 				"key": "shift+cmd+p",
 				"command": "workbench.action.quickOpenNavigatePreviousInFilePicker",
 				"when": "inFilesPicker && inQuickOpen"
+			},
+			{
+				"key": "ctrl+shift+r",
+				"command": "workbench.action.quickOpenNavigatePreviousInRecentFilesPicker",
+				"when": "inQuickOpen && inRecentFilesPicker"
 			},
 			{
 				"key": "ctrl+shift+q",
@@ -2394,49 +5055,169 @@
 				"when": "isDevelopment"
 			},
 			{
+				"key": "shift+cmd+f",
+				"command": "workbench.action.terminal.searchWorkspace",
+				"when": "terminalFocus && terminalProcessSupported && terminalTextSelected"
+			},
+			{
 				"key": "alt+cmd+i",
 				"command": "workbench.action.toggleDevTools",
 				"when": "isDevelopment"
 			},
 			{
-				"key": "cmd+f4",
-				"command": "extension.node-debug.pickLoadedScript",
-				"when": "debugType == 'node2'"
+				"key": "escape",
+				"command": "notifications.hideToasts",
+				"when": "notificationFocus && notificationToastsVisible"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.chat.stopListening",
+				"when": "voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || voiceChatInProgress && scopedVoiceChatInProgress == 'view'"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.chat.stopReadChatItemAloud",
+				"when": "scopedChatSynthesisInProgress"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.editorDictation.stop",
+				"when": "editorDictation.inProgress"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.speech.stopReadAloud",
+				"when": "scopedChatSynthesisInProgress && textToSpeechInProgress"
 			},
 			{
 				"key": "f10",
 				"command": "extension.node-debug.startWithStopOnEntry",
-				"when": "!inDebugMode && debugConfigurationType == 'node'"
+				"when": "!inDebugMode && debugConfigurationType == 'node' || !inDebugMode && debugConfigurationType == 'pwa-extensionHost' || !inDebugMode && debugConfigurationType == 'pwa-node'"
+			},
+			{
+				"key": "cmd+k alt+cmd+s",
+				"command": "git.stageSelectedRanges",
+				"when": "isInDiffEditor && !operationInProgress"
 			},
 			{
 				"key": "shift+cmd+v",
 				"command": "markdown.showPreview",
-				"when": "editorLangId == 'markdown'"
+				"when": "!notebookEditorFocused && editorLangId == 'markdown'"
 			},
 			{
 				"key": "shift+alt+f12",
-				"command": "references-view.find",
+				"command": "references-view.findReferences",
 				"when": "editorHasReferenceProvider"
 			},
 			{
 				"key": "f11",
 				"command": "extension.node-debug.startWithStopOnEntry",
-				"when": "!inDebugMode && debugConfigurationType == 'node'"
+				"when": "!inDebugMode && activeViewlet == 'workbench.view.debug' && debugConfigurationType == 'node' || !inDebugMode && activeViewlet == 'workbench.view.debug' && debugConfigurationType == 'pwa-extensionHost' || !inDebugMode && activeViewlet == 'workbench.view.debug' && debugConfigurationType == 'pwa-node'"
+			},
+			{
+				"key": "cmd+k cmd+n",
+				"command": "git.unstageSelectedRanges",
+				"when": "isInDiffEditor && !operationInProgress"
 			},
 			{
 				"key": "cmd+k v",
 				"command": "markdown.showPreviewToSide",
-				"when": "editorLangId == 'markdown'"
+				"when": "!notebookEditorFocused && editorLangId == 'markdown'"
 			},
 			{
 				"key": "f4",
 				"command": "references-view.next",
-				"when": "reference-list.hasResult"
+				"when": "reference-list.hasResult && references-view.canNavigate"
+			},
+			{
+				"key": "cmd+k cmd+r",
+				"command": "git.revertSelectedRanges",
+				"when": "isInDiffEditor && !operationInProgress"
 			},
 			{
 				"key": "shift+f4",
 				"command": "references-view.prev",
-				"when": "reference-list.hasResult"
+				"when": "reference-list.hasResult && references-view.canNavigate"
+			},
+			{
+				"key": "shift+alt+h",
+				"command": "references-view.showCallHierarchy",
+				"when": "editorHasCallHierarchyProvider"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.chat.insertCodeBlock",
+				"when": "accessibleViewInCodeBlock && chatIsEnabled || chatIsEnabled && inChat && !inChatInput"
+			},
+			{
+				"key": "cmd+i",
+				"command": "workbench.action.terminal.chat.start",
+				"when": "terminalChatAgentRegistered && terminalFocusInAny && terminalHasBeenCreated || terminalChatAgentRegistered && terminalFocusInAny && terminalProcessSupported"
+			},
+			{
+				"key": "cmd+.",
+				"command": "acceptSelectedCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "enter",
+				"command": "acceptSelectedCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "shift+escape",
+				"command": "hideCodeActionWidget",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "escape",
+				"command": "hideCodeActionWidget",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "cmd+enter",
+				"command": "previewSelectedCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "ctrl+n",
+				"command": "selectNextCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "cmd+down",
+				"command": "selectNextCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "down",
+				"command": "selectNextCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "ctrl+p",
+				"command": "selectPrevCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "cmd+up",
+				"command": "selectPrevCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "up",
+				"command": "selectPrevCodeAction",
+				"when": "codeActionMenuVisible"
+			},
+			{
+				"key": "escape",
+				"command": "diffEditor.exitCompareMove",
+				"when": "comparingMovedCode"
+			},
+			{
+				"key": "cmd+space",
+				"command": "editor.action.inlineEdits.accept",
+				"when": "inlineEditsVisible"
 			}
 		]
 	}

--- a/scripts/update_keybindings.py
+++ b/scripts/update_keybindings.py
@@ -1,0 +1,41 @@
+# Fetches the latest keybindings from https://github.com/codebling/vs-code-default-keybindings 
+# and updates the package.json files in the linuxkeybindings, mackeybindings and windowskeybindings directories.
+
+import json
+import re
+import requests
+
+sources = {
+    'linux': 'https://raw.githubusercontent.com/codebling/vs-code-default-keybindings/master/linux.keybindings.json',
+    'mac': 'https://raw.githubusercontent.com/codebling/vs-code-default-keybindings/master/macos.keybindings.json',
+    'windows': 'https://raw.githubusercontent.com/codebling/vs-code-default-keybindings/master/windows.keybindings.json'
+}
+
+for platform, url in sources.items():
+    # Fetch keybindings for each platform from https://github.com/codebling/vs-code-default-keybindings
+    response = requests.get(url)
+    response.raise_for_status()
+    body = response.text
+
+    # Get all lines starting with "//"
+    comments = '\n'.join([line for line in body.splitlines() if line.startswith('//')])
+  
+    # Remove all lines starting with "//"
+    keybindings = json.loads('\n'.join([line for line in body.splitlines() if not line.startswith('//')]))
+    
+    # Extract version from comments using regex
+    version = re.search(r'\d+\.\d+\.\d+', comments).group(0)
+
+    # Load package.json
+    with open(f'{platform}keybindings/package.json', 'r+') as f:
+        # Load in the package.json file
+        package = json.load(f)
+
+        # Update the package.json file with the new keybindings and version
+        package['version'] = version
+        package['engines']['vscode'] = f'^{version}'
+        package['contributes']['keybindings'] = keybindings
+        
+        # Write changes to the package.json file
+        f.seek(0)
+        json.dump(package, f, indent='\t')

--- a/windowskeybindings/CHANGELOG.md
+++ b/windowskeybindings/CHANGELOG.md
@@ -2,6 +2,12 @@
 All major and minor version changes will be documented in this file. Details of
 patch-level version changes can be found in [commit messages](../../commits/master).
 
+## 1.91.1 - 2024/07/17
+- Update for vscode 1.91
+- Use keybindings from [vs-code-default-keybindings](https://github.com/codebling/vs-code-default-keybindings)
+- Add auto-update for keybindings
+
+
 ## 1.58.0 - 2021/07/23
 - Update for VSCode 1.58
 - Removed duplicate keybindings for mac/ linux

--- a/windowskeybindings/README.md
+++ b/windowskeybindings/README.md
@@ -21,6 +21,8 @@
 
 Use Windows Keybindings on any OS
 
+Keybindings provided by https://github.com/codebling/vs-code-default-keybindings - Thank you!
+
 This extension does not remove any existing bindings. On the same os as that of
 the keybindings that means everything will be bound twice. On other OS' that
 means that the keybindings will be in addition to the default (note that they

--- a/windowskeybindings/package.json
+++ b/windowskeybindings/package.json
@@ -9,9 +9,9 @@
 	"icon": "Windows.png",
 	"license": "BSD-2-Clause-Patent",
 	"publisher": "fredhappyface",
-	"version": "1.87.2",
+	"version": "1.91.1",
 	"engines": {
-		"vscode": "^1.87.2"
+		"vscode": "^1.91.1"
 	},
 	"categories": [
 		"Keymaps"
@@ -316,24 +316,14 @@
 				"when": "editorHasMultipleSelections && textInputFocus"
 			},
 			{
-				"key": "enter",
-				"command": "inlineChat.accept",
-				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatVisible && !inlineChatEmpty"
-			},
-			{
-				"key": "enter",
-				"command": "notebook.cell.chat.accept",
-				"when": "inlineChatFocused && notebookCellChatFocused"
-			},
-			{
 				"key": "ctrl+down",
 				"command": "notebook.cell.chat.arrowOutDown",
-				"when": "inlineChatFocused && inlineChatInnerCursorLast && notebookCellChatFocused && !accessibilityModeEnabled"
+				"when": "inlineChatFocused && inlineChatInnerCursorLast && notebookCellChatFocused && !accessibilityModeEnabled && !notebookCellEditorFocused"
 			},
 			{
 				"key": "ctrl+up",
 				"command": "notebook.cell.chat.arrowOutUp",
-				"when": "inlineChatFocused && inlineChatInnerCursorFirst && notebookCellChatFocused && !accessibilityModeEnabled"
+				"when": "inlineChatFocused && inlineChatInnerCursorFirst && notebookCellChatFocused && !accessibilityModeEnabled && !notebookCellEditorFocused"
 			},
 			{
 				"key": "ctrl+up",
@@ -356,19 +346,19 @@
 				"when": "editorTextFocus && inlineChatVisible && !accessibilityModeEnabled && !inlineChatFocused && !isEmbeddedDiffEditor && inlineChatOuterCursorPosition == 'below'"
 			},
 			{
+				"key": "escape",
+				"command": "notebook.cell.chat.acceptChanges",
+				"when": "inlineChatFocused && notebookCellChatFocused && notebookChatUserDidEdit && !notebookCellEditorFocused"
+			},
+			{
 				"key": "down",
-				"command": "inlineChat.nextFromHistory",
-				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatInnerCursorEnd"
+				"command": "notebook.cell.chat.nextFromHistory",
+				"when": "inlineChatFocused && notebookCellChatFocused"
 			},
 			{
 				"key": "up",
-				"command": "inlineChat.previousFromHistory",
-				"when": "inlineChatFocused && inlineChatHasProvider && inlineChatInnerCursorStart"
-			},
-			{
-				"key": "escape",
-				"command": "notebook.cell.chat.acceptChanges",
-				"when": "inlineChatFocused && notebookCellChatFocused && notebookChatUserDidEdit"
+				"command": "notebook.cell.chat.previousFromHistory",
+				"when": "inlineChatFocused && notebookCellChatFocused"
 			},
 			{
 				"key": "f12",
@@ -391,7 +381,7 @@
 				"when": "inReferenceSearchEditor || referenceSearchVisible"
 			},
 			{
-				"key": "shift+enter",
+				"key": "ctrl+enter",
 				"command": "refactorPreview.apply",
 				"when": "refactorPreview.enabled && refactorPreview.hasCheckedChanges && focusedView == 'refactorPreview'"
 			},
@@ -412,13 +402,8 @@
 			},
 			{
 				"key": "escape",
-				"command": "inlineChat.cancel",
-				"when": "inlineChatHasProvider && inlineChatVisible"
-			},
-			{
-				"key": "escape",
-				"command": "inlineChat.close",
-				"when": "inlineChatHasProvider && inlineChatVisible"
+				"command": "inlineChat.discard",
+				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatUserDidEdit"
 			},
 			{
 				"key": "ctrl+f",
@@ -433,12 +418,12 @@
 			{
 				"key": "ctrl+up",
 				"command": "chat.action.focus",
-				"when": "chatCursorAtTop && inChatInput"
+				"when": "chatCursorAtTop && inChatInput && chatLocation == 'panel'"
 			},
 			{
 				"key": "ctrl+up",
 				"command": "chat.action.focus",
-				"when": "inChatInput && isLinux || inChatInput && isWindows"
+				"when": "inChatInput && isLinux && chatLocation == 'panel' || inChatInput && isWindows && chatLocation == 'panel'"
 			},
 			{
 				"key": "shift+escape",
@@ -668,6 +653,21 @@
 				"key": "escape",
 				"command": "editor.action.inlineEdit.reject",
 				"when": "inlineEditVisible && !editorReadonly"
+			},
+			{
+				"key": "escape",
+				"command": "editor.action.inlineEdits.hide",
+				"when": "inlineEditsVisible"
+			},
+			{
+				"key": "alt+]",
+				"command": "editor.action.inlineEdits.showNext",
+				"when": "inlineEditsVisible && !editorReadonly"
+			},
+			{
+				"key": "alt+[",
+				"command": "editor.action.inlineEdits.showPrevious",
+				"when": "inlineEditsVisible && !editorReadonly"
 			},
 			{
 				"key": "escape",
@@ -1146,6 +1146,16 @@
 				"when": "hasSymbols"
 			},
 			{
+				"key": "escape",
+				"command": "editor.hideDropWidget",
+				"when": "dropWidgetVisible"
+			},
+			{
+				"key": "escape",
+				"command": "editor.hidePasteWidget",
+				"when": "pasteWidgetVisible"
+			},
+			{
 				"key": "ctrl+k ctrl+.",
 				"command": "editor.removeManualFoldingRanges",
 				"when": "editorTextFocus && foldingEnabled"
@@ -1153,6 +1163,11 @@
 			{
 				"key": "ctrl+k ctrl+l",
 				"command": "editor.toggleFold",
+				"when": "editorTextFocus && foldingEnabled"
+			},
+			{
+				"key": "ctrl+k ctrl+shift+l",
+				"command": "editor.toggleFoldRecursively",
 				"when": "editorTextFocus && foldingEnabled"
 			},
 			{
@@ -1186,21 +1201,6 @@
 				"when": "isReadingLineWithInlayHints"
 			},
 			{
-				"key": "escape",
-				"command": "inlineChat.acceptChanges",
-				"when": "inlineChatHasProvider && inlineChatUserDidEdit && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatUserDidEdit && inlineChatVisible && config.inlineChat.mode != 'preview'"
-			},
-			{
-				"key": "escape",
-				"command": "inlineChat.discard",
-				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatUserDidEdit"
-			},
-			{
-				"key": "escape",
-				"command": "inlineChat.stop",
-				"when": "inlineChatHasActiveRequest && inlineChatHasProvider && inlineChatVisible && !inlineChatEmpty"
-			},
-			{
 				"key": "tab",
 				"command": "insertSnippet",
 				"when": "editorTextFocus && hasSnippetCompletions && !editorTabMovesFocus && !inSnippetMode"
@@ -1211,9 +1211,19 @@
 				"when": "activeEditor == 'workbench.editor.interactive'"
 			},
 			{
+				"key": "shift+enter",
+				"command": "interactive.execute",
+				"when": "config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+			},
+			{
+				"key": "enter",
+				"command": "interactive.execute",
+				"when": "!config.interactiveWindow.executeWithShiftEnter && activeEditor == 'workbench.editor.interactive'"
+			},
+			{
 				"key": "escape",
 				"command": "notebook.cell.chat.discard",
-				"when": "inlineChatFocused && notebookCellChatFocused && !notebookChatUserDidEdit"
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused && !notebookChatUserDidEdit"
 			},
 			{
 				"key": "pagedown",
@@ -1223,7 +1233,7 @@
 			{
 				"key": "shift+pagedown",
 				"command": "notebook.cell.cursorPageDownSelect",
-				"when": "editorTextFocus && inputFocus && notebookEditorFocused"
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused"
 			},
 			{
 				"key": "pageup",
@@ -1233,12 +1243,12 @@
 			{
 				"key": "shift+pageup",
 				"command": "notebook.cell.cursorPageUpSelect",
-				"when": "editorTextFocus && inputFocus && notebookEditorFocused"
+				"when": "editorTextFocus && inputFocus && notebookEditorFocused && !notebookOutputFocused"
 			},
 			{
 				"key": "ctrl+alt+enter",
 				"command": "notebook.cell.execute",
-				"when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelCount > 0 || notebookCellListFocused && !notebookCellExecuting && notebookCellType == 'code' && notebookKernelSourceCount > 0"
+				"when": "notebookCellListFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code' || !notebookCellExecuting && notebookCellType == 'code' && notebookCellListFocused || inlineChatFocused && notebookCellChatFocused && notebookKernelCount > 0 || !notebookCellExecuting && notebookCellType == 'code' && notebookCellListFocused || inlineChatFocused && notebookCellChatFocused && notebookKernelSourceCount > 0 || inlineChatFocused && notebookCellChatFocused && notebookMissingKernelExtension && !notebookCellExecuting && notebookCellType == 'code'"
 			},
 			{
 				"key": "alt+enter",
@@ -1335,19 +1345,24 @@
 				"command": "workbench.action.addComment"
 			},
 			{
-				"key": "enter",
-				"command": "workbench.action.chat.acceptInput",
-				"when": "inChatInput && textInputFocus"
+				"key": "ctrl+/",
+				"command": "workbench.action.chat.attachContext",
+				"when": "inChatInput"
 			},
 			{
 				"key": "ctrl+alt+enter",
 				"command": "workbench.action.chat.runInTerminal",
-				"when": "hasChatProvider && inChat"
+				"when": "accessibleViewInCodeBlock && chatIsEnabled || chatIsEnabled && inChat"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.chat.submit",
+				"when": "chatInputHasText && inChatInput && !chatSessionRequestInProgress"
 			},
 			{
 				"key": "ctrl+enter",
 				"command": "workbench.action.chat.submitSecondaryAgent",
-				"when": "inChatInput && textInputFocus"
+				"when": "chatInputHasText && inChatInput && !chatInputHasAgent && !chatSessionRequestInProgress"
 			},
 			{
 				"key": "alt+f5",
@@ -1461,23 +1476,18 @@
 			},
 			{
 				"key": "ctrl+enter",
-				"command": "inlineChat.acceptChanges",
-				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.mode != 'preview'"
-			},
-			{
-				"key": "ctrl+enter",
 				"command": "notebook.cell.chat.acceptChanges",
-				"when": "inlineChatFocused && notebookCellChatFocused"
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused"
 			},
 			{
 				"key": "tab",
 				"command": "jumpToNextSnippetPlaceholder",
-				"when": "editorTextFocus && hasNextTabstop && inSnippetMode"
+				"when": "hasNextTabstop && inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "shift+tab",
 				"command": "jumpToPrevSnippetPlaceholder",
-				"when": "editorTextFocus && hasPrevTabstop && inSnippetMode"
+				"when": "hasPrevTabstop && inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "escape",
@@ -1487,12 +1497,12 @@
 			{
 				"key": "shift+escape",
 				"command": "leaveSnippet",
-				"when": "editorTextFocus && inSnippetMode"
+				"when": "inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "escape",
 				"command": "leaveSnippet",
-				"when": "editorTextFocus && inSnippetMode"
+				"when": "inSnippetMode && textInputFocus"
 			},
 			{
 				"key": "shift+escape",
@@ -1665,7 +1675,7 @@
 				"when": "editorFocus && renameInputVisible && !isComposing"
 			},
 			{
-				"key": "shift+enter",
+				"key": "ctrl+enter",
 				"command": "acceptRenameInputWithPreview",
 				"when": "config.editor.rename.enablePreview && editorFocus && renameInputVisible && !isComposing"
 			},
@@ -1695,24 +1705,9 @@
 				"when": "renameInputVisible"
 			},
 			{
-				"key": "tab",
-				"command": "focusNextRenameSuggestion",
-				"when": "renameInputVisible"
-			},
-			{
 				"key": "up",
 				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputVisible && !renameInputFocused"
-			},
-			{
-				"key": "alt",
-				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputFocused && renameInputVisible"
-			},
-			{
-				"key": "shift+tab",
-				"command": "focusPreviousRenameSuggestion",
-				"when": "renameInputVisible && !renameInputFocused"
+				"when": "renameInputVisible"
 			},
 			{
 				"key": "ctrl+shift+l",
@@ -1860,6 +1855,16 @@
 				"when": "!accessibilityHelpIsShown"
 			},
 			{
+				"key": "alt+k",
+				"command": "editor.action.accessibilityHelpConfigureKeybindings",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
+				"key": "alt+h",
+				"command": "editor.action.accessibilityHelpOpenHelpLink",
+				"when": "accessibilityHelpIsShown"
+			},
+			{
 				"key": "alt+f2",
 				"command": "editor.action.accessibleView"
 			},
@@ -1879,14 +1884,24 @@
 				"when": "accessibleViewIsShown && accessibleViewSupportsNavigation"
 			},
 			{
+				"key": "ctrl+alt+pagedown",
+				"command": "editor.action.accessibleViewNextCodeBlock",
+				"when": "accessibleViewContainsCodeBlocks && accessibleViewCurrentProviderId == 'panelChat'"
+			},
+			{
 				"key": "alt+[",
 				"command": "editor.action.accessibleViewPrevious",
 				"when": "accessibleViewIsShown && accessibleViewSupportsNavigation"
 			},
 			{
+				"key": "ctrl+alt+pageup",
+				"command": "editor.action.accessibleViewPreviousCodeBlock",
+				"when": "accessibleViewContainsCodeBlocks && accessibleViewCurrentProviderId == 'panelChat'"
+			},
+			{
 				"key": "ctrl+k ctrl+k",
 				"command": "editor.action.defineKeybinding",
-				"when": "resource == 'vscode-userdata:/c%3A/Users/Dell/AppData/Roaming/VSCodium/User/keybindings.json'"
+				"when": "resource == 'vscode-userdata:/d%3A/a/vs-code-default-keybindings/vs-code-default-keybindings/scripts/get_default_keybindings/empty2/User/keybindings.json'"
 			},
 			{
 				"key": "tab",
@@ -1999,6 +2014,16 @@
 				"when": "inSearchEditor"
 			},
 			{
+				"key": "escape",
+				"command": "inlineChat.close",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
+				"key": "escape",
+				"command": "inlineChat.discardHunkChange",
+				"when": "inlineChatHasProvider && inlineChatVisible && inlineChatResponseType == 'messagesAndEdits'"
+			},
+			{
 				"key": "ctrl+i",
 				"command": "inlineChat.holdForSpeech",
 				"when": "hasSpeechProvider && inlineChatHasProvider && inlineChatVisible && textInputFocus"
@@ -2014,9 +2039,9 @@
 				"when": "inlineChatHasProvider && inlineChatVisible"
 			},
 			{
-				"key": "escape",
-				"command": "inlineChat.quickVoice.Cancel",
-				"when": "hasSpeechProvider && inlineChat.quickChatInProgress"
+				"key": "ctrl+r",
+				"command": "inlineChat.regenerate",
+				"when": "inlineChatHasProvider && inlineChatVisible"
 			},
 			{
 				"key": "ctrl+k i",
@@ -2034,14 +2059,29 @@
 				"when": "inlineChatHasStashedSession && !editorReadonly"
 			},
 			{
+				"key": "ctrl+down",
+				"command": "inlineChat.viewInChat",
+				"when": "inlineChatHasProvider && inlineChatVisible"
+			},
+			{
 				"key": "down",
 				"command": "interactive.history.next",
 				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.interactive' && interactiveInputCursorAtBoundary != 'none' && interactiveInputCursorAtBoundary != 'top'"
 			},
 			{
+				"key": "down",
+				"command": "interactive.history.next",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.repl' && interactiveInputCursorAtBoundary != 'none' && interactiveInputCursorAtBoundary != 'top'"
+			},
+			{
 				"key": "up",
 				"command": "interactive.history.previous",
 				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.interactive' && interactiveInputCursorAtBoundary != 'bottom' && interactiveInputCursorAtBoundary != 'none'"
+			},
+			{
+				"key": "up",
+				"command": "interactive.history.previous",
+				"when": "!suggestWidgetVisible && activeEditor == 'workbench.editor.repl' && interactiveInputCursorAtBoundary != 'bottom' && interactiveInputCursorAtBoundary != 'none'"
 			},
 			{
 				"key": "ctrl+end",
@@ -2154,7 +2194,7 @@
 				"when": "listFocus && listSupportsFind"
 			},
 			{
-				"key": "ctrl+f",
+				"key": "ctrl+alt+f",
 				"command": "list.find",
 				"when": "listFocus && listSupportsFind"
 			},
@@ -2229,6 +2269,11 @@
 				"when": "listFocus && listSupportsMultiselect && !inputFocus && !treestickyScrollFocused"
 			},
 			{
+				"key": "ctrl+k ctrl+i",
+				"command": "list.showHover",
+				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
+			},
+			{
 				"key": "space",
 				"command": "list.toggleExpand",
 				"when": "listFocus && !inputFocus && !treestickyScrollFocused"
@@ -2249,9 +2294,14 @@
 				"when": "notebookEditorFocused && !inputFocus && !notebookOutputFocused && activeEditor == 'workbench.editor.notebook' && notebookCellType == 'code'"
 			},
 			{
+				"key": "enter",
+				"command": "notebook.cell.chat.accept",
+				"when": "inlineChatFocused && notebookCellChatFocused && !notebookCellEditorFocused"
+			},
+			{
 				"key": "ctrl+enter",
 				"command": "notebook.cell.chat.acceptChanges",
-				"when": "notebookEditorFocused && !inputFocus && notebookChatOuterFocusPosition == 'below'"
+				"when": "notebookEditorFocused && !inputFocus && !notebookCellEditorFocused && notebookChatOuterFocusPosition == 'below'"
 			},
 			{
 				"key": "ctrl+down",
@@ -2272,6 +2322,16 @@
 				"key": "ctrl+up",
 				"command": "notebook.cell.chat.focusPreviousCell",
 				"when": "inlineChatFocused && notebookCellChatFocused"
+			},
+			{
+				"key": "ctrl+k i",
+				"command": "notebook.cell.chat.start",
+				"when": "config.notebook.experimental.cellChat && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus || config.notebook.experimental.generate && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "notebook.cell.chat.start",
+				"when": "config.notebook.experimental.cellChat && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus || config.notebook.experimental.generate && notebookChatAgentRegistered && notebookEditable && notebookEditorFocused && !inputFocus"
 			},
 			{
 				"key": "alt+delete",
@@ -2301,7 +2361,7 @@
 			{
 				"key": "delete",
 				"command": "notebook.cell.delete",
-				"when": "notebookEditorFocused && !inputFocus"
+				"when": "notebookEditorFocused && !inputFocus && !notebookOutputInputFocused"
 			},
 			{
 				"key": "shift+alt+d",
@@ -2311,7 +2371,7 @@
 			{
 				"key": "enter",
 				"command": "notebook.cell.edit",
-				"when": "notebookCellListFocused && notebookEditable && !editorHoverFocused && !inputFocus"
+				"when": "notebookCellListFocused && notebookEditable && !editorHoverFocused && !inputFocus && !notebookOutputInputFocused"
 			},
 			{
 				"key": "ctrl+k ctrl+c",
@@ -2364,6 +2424,11 @@
 				"when": "notebookEditorFocused && !inputFocus"
 			},
 			{
+				"key": "ctrl+.",
+				"command": "notebook.cell.openFailureActions",
+				"when": "notebookCellFocused && notebookCellHasErrorDiagnostics && !notebookCellEditorFocused"
+			},
+			{
 				"key": "ctrl+k ctrl+shift+\\",
 				"command": "notebook.cell.split",
 				"when": "editorTextFocus && notebookCellEditable && notebookEditable && notebookEditorFocused"
@@ -2409,19 +2474,9 @@
 				"when": "notebookEditorFocused && notebookOutputFocused"
 			},
 			{
-				"key": "ctrl+alt+pagedown",
-				"command": "notebook.focusNextEditor",
-				"when": "notebookEditorFocused"
-			},
-			{
 				"key": "up",
 				"command": "notebook.focusPreviousEditor",
 				"when": "config.notebook.navigation.allowNavigateToSurroundingCells && notebookCursorNavigationMode && notebookEditorFocused && !accessibilityModeEnabled && !isEmbeddedDiffEditor && !notebookCellMarkdownEditMode && notebookCellType == 'markup'"
-			},
-			{
-				"key": "ctrl+alt+pageup",
-				"command": "notebook.focusPreviousEditor",
-				"when": "notebookEditorFocused"
 			},
 			{
 				"key": "ctrl+home",
@@ -2558,6 +2613,106 @@
 				"when": "problemFocus"
 			},
 			{
+				"key": "ctrl+alt+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+home",
+				"command": "quickInput.first",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+end",
+				"command": "quickInput.last",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+down",
+				"command": "quickInput.next",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "down",
+				"command": "quickInput.next",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+down",
+				"command": "quickInput.nextSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+down",
+				"command": "quickInput.nextSeparatorWithQuickAccessFallback",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "pagedown",
+				"command": "quickInput.pageNext",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "pageup",
+				"command": "quickInput.pagePrevious",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+up",
+				"command": "quickInput.previous",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "up",
+				"command": "quickInput.previous",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+alt+up",
+				"command": "quickInput.previousSeparator",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+up",
+				"command": "quickInput.previousSeparatorWithQuickAccessFallback",
+				"when": "inQuickInput && quickInputType == 'quickPick'"
+			},
+			{
 				"key": "space",
 				"command": "refactorPreview.toggleCheckedState",
 				"when": "listFocus && refactorPreview.enabled && !inputFocus && !treestickyScrollFocused"
@@ -2580,6 +2735,11 @@
 				"key": "ctrl+enter",
 				"command": "scm.acceptInput",
 				"when": "scmRepository"
+			},
+			{
+				"key": "escape",
+				"command": "scm.clearInput",
+				"when": "scmRepository && !suggestWidgetVisible"
 			},
 			{
 				"key": "alt+down",
@@ -2813,8 +2973,7 @@
 			},
 			{
 				"key": "ctrl+; ctrl+shift+i",
-				"command": "testing.toggleInlineCoverage",
-				"when": "testing.isTestCoverageOpen"
+				"command": "testing.toggleInlineCoverage"
 			},
 			{
 				"key": "ctrl+; ctrl+i",
@@ -2880,6 +3039,10 @@
 				"when": "inputFocus && navigableContainerFocused || navigableContainerFocused && treestickyScrollFocused || navigableContainerFocused && !listFocus || navigableContainerFocused && listScrollAtBoundary == 'both' || navigableContainerFocused && listScrollAtBoundary == 'top'"
 			},
 			{
+				"key": "alt+backspace",
+				"command": "workbench.action.chat.cancel"
+			},
+			{
 				"key": "ctrl+down",
 				"command": "workbench.action.chat.focusInput",
 				"when": "inChat && !inChatInput"
@@ -2887,42 +3050,36 @@
 			{
 				"key": "ctrl+i",
 				"command": "workbench.action.chat.holdToVoiceChatInChatView",
-				"when": "hasChatProvider && hasSpeechProvider && !editorFocus && !inChatInput && !inlineChatFocused"
-			},
-			{
-				"key": "ctrl+enter",
-				"command": "workbench.action.chat.insertCodeBlock",
-				"when": "hasChatProvider && inChat && !inChatInput"
+				"when": "chatIsEnabled && hasSpeechProvider && !chatSessionRequestInProgress && !editorFocus && !inChatInput && !inlineChatFocused && !notebookEditorFocused"
 			},
 			{
 				"key": "ctrl+l",
 				"command": "workbench.action.chat.newChat",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+alt+pagedown",
 				"command": "workbench.action.chat.nextCodeBlock",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+f9",
 				"command": "workbench.action.chat.nextFileTree",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+alt+i",
-				"command": "workbench.action.chat.open",
-				"when": "hasChatProvider"
+				"command": "workbench.action.chat.open"
 			},
 			{
 				"key": "ctrl+alt+pageup",
 				"command": "workbench.action.chat.previousCodeBlock",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "ctrl+shift+f9",
 				"command": "workbench.action.chat.previousFileTree",
-				"when": "hasChatProvider && inChat"
+				"when": "chatIsEnabled && inChat"
 			},
 			{
 				"key": "delete",
@@ -2930,14 +3087,19 @@
 				"when": "inChat && !inChatInput"
 			},
 			{
+				"key": "ctrl+shift+enter",
+				"command": "workbench.action.chat.sendToNewChat",
+				"when": "chatInputHasText && inChatInput && !chatSessionRequestInProgress"
+			},
+			{
 				"key": "ctrl+i",
 				"command": "workbench.action.chat.startVoiceChat",
-				"when": "hasChatProvider && hasSpeechProvider && inChatInput && !chatSessionRequestInProgress && !editorFocus && !inlineChatHasActiveRequest && !inlineVoiceChatInProgress && !quickVoiceChatInProgress && !voiceChatGettingReady && !voiceChatInEditorInProgress && !voiceChatInViewInProgress || hasChatProvider && hasSpeechProvider && inlineChatFocused && !chatSessionRequestInProgress && !editorFocus && !inlineChatHasActiveRequest && !inlineVoiceChatInProgress && !quickVoiceChatInProgress && !voiceChatGettingReady && !voiceChatInEditorInProgress && !voiceChatInViewInProgress"
+				"when": "chatIsEnabled && hasSpeechProvider && inChatInput && !chatSessionRequestInProgress && !editorFocus && !notebookEditorFocused && !scopedVoiceChatGettingReady && !speechToTextInProgress && !terminalChatActiveRequest || chatIsEnabled && hasSpeechProvider && inlineChatFocused && !chatSessionRequestInProgress && !editorFocus && !notebookEditorFocused && !scopedVoiceChatGettingReady && !speechToTextInProgress && !terminalChatActiveRequest"
 			},
 			{
 				"key": "ctrl+i",
 				"command": "workbench.action.chat.stopListeningAndSubmit",
-				"when": "hasChatProvider && hasSpeechProvider && inChatInput && voiceChatInProgress || hasChatProvider && hasSpeechProvider && inlineChatFocused && voiceChatInProgress"
+				"when": "inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || inChatInput && voiceChatInProgress && scopedVoiceChatInProgress == 'view' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || inlineChatFocused && voiceChatInProgress && scopedVoiceChatInProgress == 'view'"
 			},
 			{
 				"key": "ctrl+w",
@@ -3062,9 +3224,14 @@
 				"when": "!notebookEditorFocused"
 			},
 			{
+				"key": "alt+`",
+				"command": "workbench.action.editorDictation.start",
+				"when": "hasSpeechProvider && !editorReadonly && !speechToTextInProgress"
+			},
+			{
 				"key": "ctrl+alt+v",
 				"command": "workbench.action.editorDictation.start",
-				"when": "hasSpeechProvider && !editorDictation.inProgress && !editorReadonly"
+				"when": "hasSpeechProvider && !editorReadonly && !speechToTextInProgress"
 			},
 			{
 				"key": "ctrl+k p",
@@ -3396,7 +3563,7 @@
 			{
 				"key": "ctrl+shift+i",
 				"command": "workbench.action.quickchat.toggle",
-				"when": "hasChatProvider"
+				"when": "chatIsEnabled"
 			},
 			{
 				"key": "ctrl+alt+o",
@@ -3436,11 +3603,6 @@
 				"command": "workbench.action.showCommands"
 			},
 			{
-				"key": "ctrl+k ctrl+i",
-				"command": "workbench.action.showTreeHover",
-				"when": "customTreeView && listFocus && !inputFocus && !treestickyScrollFocused"
-			},
-			{
 				"key": "ctrl+\\",
 				"command": "workbench.action.splitEditor"
 			},
@@ -3473,6 +3635,76 @@
 				"key": "ctrl+shift+b",
 				"command": "workbench.action.tasks.build",
 				"when": "taskCommandsRegistered"
+			},
+			{
+				"key": "shift+escape",
+				"command": "workbench.action.terminal.chat.close",
+				"when": "terminalChatFocus && terminalChatVisible"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.terminal.chat.close",
+				"when": "terminalChatFocus && terminalChatVisible"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "workbench.action.terminal.chat.focusInput",
+				"when": "terminalChatFocus && !inlineChatFocused"
+			},
+			{
+				"key": "ctrl+up",
+				"command": "workbench.action.terminal.chat.focusInput",
+				"when": "terminalChatFocus && !inlineChatFocused"
+			},
+			{
+				"key": "ctrl+down",
+				"command": "workbench.action.terminal.chat.focusResponse",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "ctrl+alt+enter",
+				"command": "workbench.action.terminal.chat.insertCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "alt+enter",
+				"command": "workbench.action.terminal.chat.insertCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "ctrl+alt+enter",
+				"command": "workbench.action.terminal.chat.insertFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
+			},
+			{
+				"key": "alt+enter",
+				"command": "workbench.action.terminal.chat.insertFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
+			},
+			{
+				"key": "enter",
+				"command": "workbench.action.terminal.chat.makeRequest",
+				"when": "terminalChatFocus && terminalHasBeenCreated && !inlineChatEmpty && !terminalChatActiveRequest || terminalChatFocus && terminalProcessSupported && !inlineChatEmpty && !terminalChatActiveRequest"
+			},
+			{
+				"key": "down",
+				"command": "workbench.action.terminal.chat.nextFromHistory",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "up",
+				"command": "workbench.action.terminal.chat.previousFromHistory",
+				"when": "terminalChatFocus"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.terminal.chat.runCommand",
+				"when": "terminalChatResponseContainsCodeBlock && terminalHasBeenCreated && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks || terminalChatResponseContainsCodeBlock && terminalProcessSupported && !terminalChatActiveRequest && !terminalChatResponseContainsMultipleCodeBlocks"
+			},
+			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.terminal.chat.runFirstCommand",
+				"when": "terminalChatResponseContainsMultipleCodeBlocks && terminalHasBeenCreated && !terminalChatActiveRequest || terminalChatResponseContainsMultipleCodeBlocks && terminalProcessSupported && !terminalChatActiveRequest"
 			},
 			{
 				"key": "escape",
@@ -3729,7 +3961,7 @@
 			{
 				"key": "ctrl+space",
 				"command": "workbench.action.terminal.sendSequence",
-				"when": "config.terminal.integrated.shellIntegration.suggestEnabled && terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
+				"when": "config.terminal.integrated.suggest.enabled && terminalFocus && terminalShellIntegrationEnabled && !accessibilityModeEnabled && terminalShellType == 'pwsh'",
 				"args": {
 					"text": "\u001b[24~e"
 				}
@@ -3821,17 +4053,17 @@
 			{
 				"key": "alt+c",
 				"command": "workbench.action.terminal.toggleFindCaseSensitive",
-				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "alt+r",
 				"command": "workbench.action.terminal.toggleFindRegex",
-				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "alt+w",
 				"command": "workbench.action.terminal.toggleFindWholeWord",
-				"when": "terminalFindFocused && terminalHasBeenCreated || terminalFindFocused && terminalProcessSupported || terminalFocusInAny && terminalHasBeenCreated || terminalFocusInAny && terminalProcessSupported"
+				"when": "terminalFindVisible && terminalHasBeenCreated || terminalFindVisible && terminalProcessSupported"
 			},
 			{
 				"key": "ctrl+`",
@@ -4026,6 +4258,31 @@
 				"when": "breadcrumbsActive && breadcrumbsVisible"
 			},
 			{
+				"key": "down",
+				"command": "notebook.cell.nullAction",
+				"when": "notebookOutputInputFocused"
+			},
+			{
+				"key": "up",
+				"command": "notebook.cell.nullAction",
+				"when": "notebookOutputInputFocused"
+			},
+			{
+				"key": "ctrl+a",
+				"command": "notebook.cell.output.selectAll",
+				"when": "notebookEditorFocused && notebookOutputFocused"
+			},
+			{
+				"key": "ctrl+pagedown",
+				"command": "notebook.focusNextEditor",
+				"when": "accessibilityModeEnabled && notebookCellEditorFocused"
+			},
+			{
+				"key": "ctrl+pageup",
+				"command": "notebook.focusPreviousEditor",
+				"when": "accessibilityModeEnabled && notebookCellEditorFocused"
+			},
+			{
 				"key": "ctrl+k down",
 				"command": "views.moveViewDown",
 				"when": "focusedView != ''"
@@ -4210,6 +4467,11 @@
 				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedFirstFocus && !inputFocus"
 			},
 			{
+				"key": "ctrl+enter",
+				"command": "inlineChat.acceptChanges",
+				"when": "inlineChatHasProvider && inlineChatVisible && !inlineChatDocumentChanged || inlineChatHasProvider && inlineChatVisible && config.inlineChat.mode != 'preview'"
+			},
+			{
 				"key": "end",
 				"command": "lastCompressedFolder",
 				"when": "explorerViewletCompressedFocus && filesExplorerFocus && foldersViewVisible && !explorerViewletCompressedLastFocus && !inputFocus"
@@ -4290,6 +4552,26 @@
 				"when": "notificationCenterVisible"
 			},
 			{
+				"key": "ctrl+alt+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "ctrl+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "alt+right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
+				"key": "right",
+				"command": "quickInput.acceptInBackground",
+				"when": "cursorAtEndOfQuickInputBox && inQuickInput && quickInputType == 'quickPick' || inQuickInput && !inputFocus && quickInputType == 'quickPick'"
+			},
+			{
 				"key": "alt+left",
 				"command": "workbench.action.quickInputBack",
 				"when": "inQuickOpen"
@@ -4360,16 +4642,6 @@
 				"when": "isDevelopment"
 			},
 			{
-				"key": "ctrl+k i",
-				"command": "inlineChat.quickVoice.start",
-				"when": "editorFocus && hasSpeechProvider && !inlineChat.quickChatInProgress"
-			},
-			{
-				"key": "ctrl+k i",
-				"command": "inlineChat.quickVoice.stop",
-				"when": "hasSpeechProvider && inlineChat.quickChatInProgress"
-			},
-			{
 				"key": "escape",
 				"command": "notifications.hideToasts",
 				"when": "notificationFocus && notificationToastsVisible"
@@ -4377,32 +4649,22 @@
 			{
 				"key": "escape",
 				"command": "workbench.action.chat.stopListening",
-				"when": "hasChatProvider && hasSpeechProvider && voiceChatInProgress"
+				"when": "voiceChatInProgress && scopedVoiceChatInProgress == 'editor' || voiceChatInProgress && scopedVoiceChatInProgress == 'inline' || voiceChatInProgress && scopedVoiceChatInProgress == 'quick' || voiceChatInProgress && scopedVoiceChatInProgress == 'terminal' || voiceChatInProgress && scopedVoiceChatInProgress == 'view'"
 			},
 			{
 				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInChatEditor",
-				"when": "hasChatProvider && hasSpeechProvider && voiceChatInEditorInProgress"
-			},
-			{
-				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInChatView",
-				"when": "hasChatProvider && hasSpeechProvider && voiceChatInViewInProgress"
-			},
-			{
-				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInInlineChat",
-				"when": "hasChatProvider && hasSpeechProvider && inlineVoiceChatInProgress"
-			},
-			{
-				"key": "escape",
-				"command": "workbench.action.chat.stopListeningInQuickChat",
-				"when": "hasChatProvider && hasSpeechProvider && quickVoiceChatInProgress"
+				"command": "workbench.action.chat.stopReadChatItemAloud",
+				"when": "scopedChatSynthesisInProgress"
 			},
 			{
 				"key": "escape",
 				"command": "workbench.action.editorDictation.stop",
 				"when": "editorDictation.inProgress"
+			},
+			{
+				"key": "escape",
+				"command": "workbench.action.speech.stopReadAloud",
+				"when": "scopedChatSynthesisInProgress && textToSpeechInProgress"
 			},
 			{
 				"key": "f10",
@@ -4460,6 +4722,16 @@
 				"when": "editorHasCallHierarchyProvider"
 			},
 			{
+				"key": "ctrl+enter",
+				"command": "workbench.action.chat.insertCodeBlock",
+				"when": "accessibleViewInCodeBlock && chatIsEnabled || chatIsEnabled && inChat && !inChatInput"
+			},
+			{
+				"key": "ctrl+i",
+				"command": "workbench.action.terminal.chat.start",
+				"when": "terminalChatAgentRegistered && terminalFocusInAny && terminalHasBeenCreated || terminalChatAgentRegistered && terminalFocusInAny && terminalProcessSupported"
+			},
+			{
 				"key": "ctrl+.",
 				"command": "acceptSelectedCodeAction",
 				"when": "codeActionMenuVisible"
@@ -4508,6 +4780,11 @@
 				"key": "escape",
 				"command": "diffEditor.exitCompareMove",
 				"when": "comparingMovedCode"
+			},
+			{
+				"key": "ctrl+space",
+				"command": "editor.action.inlineEdits.accept",
+				"when": "inlineEditsVisible"
 			}
 		]
 	}


### PR DESCRIPTION
### Purpose of This Pull Request

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other (please explain):

### Overview of Changes

This PR updates all three extensions with the latest keybindings from VSCode via [vs-code-default-keybindings](https://github.com/codebling/vs-code-default-keybindings), a very neat little project that automatically extracts the latest keybindings from the MacOS, Linux and Windows VSCode installation.

This PR includes a script, `scripts/update_keybindings.py`, that fetches the latest keybindings and updates them in the relevant extension's `package.json` file. It also includes an GitHub workflow, that on a schedule, checks if there are new keybindings available and if there is raises a PR with the included updates.